### PR TITLE
Add entidades cards view and JSON endpoint

### DIFF
--- a/app/Views/comercial/entidades/index_cards.php
+++ b/app/Views/comercial/entidades/index_cards.php
@@ -1,0 +1,223 @@
+<?php
+/** @var array $items */
+/** @var array $crumbs */
+/** @var string $csrf */
+/** @var string $q */
+/** @var int $total */
+/** @var int $page */
+/** @var int $perPage */
+
+$crumbs = $crumbs ?? [];
+$items  = is_array($items ?? null) ? $items : [];
+$q      = (string)($q ?? '');
+$total  = (int)($total ?? count($items));
+$page   = (int)($page ?? 1);
+$perPage = (int)($perPage ?? 20);
+$csrf   = (string)($csrf ?? '');
+
+function h($value): string
+{
+    return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+}
+
+function entSegmento(array $row): string
+{
+    $label = trim((string)($row['segmento'] ?? $row['segmento_nombre'] ?? ''));
+    if ($label !== '') {
+        return $label;
+    }
+    $id = $row['id_segmento'] ?? null;
+    if ($id === null || $id === '') {
+        return 'No especificado';
+    }
+    return 'Segmento ' . (int)$id;
+}
+
+function entUbicacion(array $row): string
+{
+    $prov = trim((string)($row['provincia'] ?? $row['provincia_nombre'] ?? ''));
+    $canton = trim((string)($row['canton'] ?? $row['canton_nombre'] ?? ''));
+    if ($prov === '' && $canton === '') {
+        return 'No especificado';
+    }
+    if ($prov === '') {
+        return $canton;
+    }
+    if ($canton === '') {
+        return $prov;
+    }
+    return $prov . ' - ' . $canton;
+}
+
+function entTelefono(?string $value): string
+{
+    $trim = trim((string)$value);
+    return $trim === '' ? 'No especificado' : $trim;
+}
+
+function entServicios(array $row): array
+{
+    $raw = $row['servicios'] ?? $row['servicios_activos'] ?? $row['servicios_nombres'] ?? [];
+    if (is_string($raw)) {
+        $parts = array_map('trim', preg_split('/[,;]\s*/', $raw));
+    } elseif (is_array($raw)) {
+        $parts = [];
+        foreach ($raw as $item) {
+            if (is_array($item)) {
+                $label = $item['nombre_servicio'] ?? $item['nombre'] ?? reset($item);
+            } else {
+                $label = $item;
+            }
+            $label = trim((string)$label);
+            if ($label !== '') {
+                $parts[] = $label;
+            }
+        }
+    } else {
+        $parts = [];
+    }
+    $parts = array_values(array_filter($parts, static fn($s) => $s !== ''));
+    return $parts;
+}
+
+include __DIR__ . '/../../partials/breadcrumbs.php';
+?>
+<link rel="stylesheet" href="/css/comercial_style/entidades-cards.css">
+<section class="ent-cards-wrapper" aria-labelledby="entidades-heading">
+  <header class="ent-cards-header">
+    <div class="ent-cards-header__titles">
+      <h1 id="entidades-heading" class="ent-title">Entidades financieras</h1>
+      <p class="ent-cards-header__summary" aria-live="polite">
+        <?= (int)$total ?> entidades · Página <?= (int)$page ?> de <?= max(1, (int)ceil(max(1, $total) / max(1, $perPage))) ?>
+      </p>
+    </div>
+    <div class="ent-cards-header__actions">
+      <a class="btn btn-primary" href="/comercial/entidades/crear">Nueva entidad</a>
+      <form class="ent-cards-search" action="/comercial/entidades" method="get" role="search" aria-label="Buscar entidades">
+        <label for="ent-search" class="ent-cards-search__label">Buscar por nombre o RUC</label>
+        <div class="ent-cards-search__group">
+          <input
+            id="ent-search"
+            name="q"
+            type="search"
+            value="<?= h($q) ?>"
+            placeholder="Ej. Cooperativa"
+            aria-describedby="ent-search-help"
+          >
+          <button class="btn btn-outline" type="submit">Buscar</button>
+        </div>
+        <span id="ent-search-help" class="ent-cards-search__help">Presiona enter para filtrar resultados</span>
+      </form>
+    </div>
+  </header>
+
+  <?php if (empty($items)) : ?>
+    <div class="ent-cards-empty" role="status">No se encontraron entidades con los criterios actuales.</div>
+  <?php else : ?>
+    <div class="ent-cards-grid" role="list">
+      <?php foreach ($items as $index => $row): ?>
+        <?php
+          $id = (int)($row['id'] ?? $row['id_entidad'] ?? $row['id_cooperativa'] ?? 0);
+          $nombre = $row['nombre'] ?? '';
+          $segmento = entSegmento((array)$row);
+          $ubicacion = entUbicacion((array)$row);
+          $telefonoFijo = entTelefono($row['telefono_fijo_1'] ?? $row['telefono_fijo'] ?? $row['telefono'] ?? null);
+          $telefonoMovil = entTelefono($row['telefono_movil'] ?? null);
+          $email = entTelefono($row['email'] ?? null);
+          $servicios = entServicios((array)$row);
+        ?>
+        <article class="ent-card-item" role="listitem">
+          <header class="ent-card-item__header">
+            <div class="ent-card-item__icon" aria-hidden="true">🏦</div>
+            <div class="ent-card-item__text">
+              <h2 class="ent-card-item__title"><?= h($nombre) ?></h2>
+              <p class="ent-card-item__subtitle"><?= h($segmento) ?></p>
+            </div>
+          </header>
+          <div class="ent-card-item__body">
+            <dl class="ent-card-item__details">
+              <div>
+                <dt>Ubicación</dt>
+                <dd><?= h($ubicacion) ?></dd>
+              </div>
+              <div>
+                <dt>Teléfono fijo</dt>
+                <dd><?= h($telefonoFijo) ?></dd>
+              </div>
+              <div>
+                <dt>Teléfono móvil</dt>
+                <dd><?= h($telefonoMovil) ?></dd>
+              </div>
+              <div>
+                <dt>Email</dt>
+                <dd><?= h($email) ?></dd>
+              </div>
+            </dl>
+            <div class="ent-card-item__services" aria-label="Servicios activos">
+              <?php if (!empty($servicios)): ?>
+                <?php foreach ($servicios as $serviceName): ?>
+                  <span class="ent-card-item__badge"><?= h($serviceName) ?></span>
+                <?php endforeach; ?>
+              <?php else: ?>
+                <span class="ent-card-item__badge ent-card-item__badge--empty">Sin servicios registrados</span>
+              <?php endif; ?>
+            </div>
+          </div>
+          <footer class="ent-card-item__footer">
+            <button
+              type="button"
+              class="btn btn-outline ent-card-item__action"
+              data-entity-id="<?= $id ?>"
+              aria-haspopup="dialog"
+              aria-controls="ent-card-modal"
+            >Ver</button>
+            <a class="btn btn-primary ent-card-item__action" href="/comercial/entidades/editar?id=<?= $id ?>">Editar</a>
+            <form
+              class="ent-card-item__delete"
+              method="post"
+              action="/comercial/entidades/eliminar"
+              onsubmit="return confirm('¿Deseas eliminar esta entidad?');"
+            >
+              <input type="hidden" name="_csrf" value="<?= h($csrf) ?>">
+              <input id="ent-delete-<?= $index ?>" type="hidden" name="id" value="<?= $id ?>">
+              <button class="btn btn-danger ent-card-item__action" type="submit" aria-labelledby="delete-label-<?= $index ?>">
+                <span id="delete-label-<?= $index ?>" class="visually-hidden">Eliminar <?= h($nombre) ?></span>
+                <span aria-hidden="true">Eliminar</span>
+              </button>
+            </form>
+          </footer>
+        </article>
+      <?php endforeach; ?>
+    </div>
+  <?php endif; ?>
+</section>
+
+<div id="ent-card-modal" class="ent-card-modal" aria-hidden="true">
+  <div class="ent-card-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="ent-card-modal-title">
+    <button type="button" class="ent-card-modal__close" aria-label="Cerrar modal">×</button>
+    <header class="ent-card-modal__header">
+      <div class="ent-card-item__icon" aria-hidden="true">🏦</div>
+      <div class="ent-card-modal__titles">
+        <h2 id="ent-card-modal-title" class="ent-card-item__title">Entidad</h2>
+        <p id="ent-card-modal-segmento" class="ent-card-item__subtitle">Segmento</p>
+      </div>
+      <span id="ent-card-modal-serv-count" class="ent-card-item__badge">0 servicios</span>
+    </header>
+    <div class="ent-card-modal__body">
+      <dl class="ent-card-modal__details">
+        <div><dt>Ubicación</dt><dd id="modal-ubicacion">—</dd></div>
+        <div><dt>Tipo</dt><dd id="modal-tipo">—</dd></div>
+        <div><dt>RUC</dt><dd id="modal-ruc">—</dd></div>
+        <div><dt>Teléfono fijo</dt><dd id="modal-telefono-fijo">—</dd></div>
+        <div><dt>Teléfono móvil</dt><dd id="modal-telefono-movil">—</dd></div>
+        <div><dt>Email</dt><dd id="modal-email">—</dd></div>
+        <div><dt>Notas</dt><dd id="modal-notas">—</dd></div>
+        <div><dt>Servicios</dt><dd id="modal-servicios">—</dd></div>
+      </dl>
+    </div>
+    <footer class="ent-card-modal__footer">
+      <button type="button" class="btn btn-outline ent-card-modal__close">Cerrar</button>
+    </footer>
+  </div>
+</div>
+<script src="/js/entidades_cards.js" defer></script>

--- a/config/routes.php
+++ b/config/routes.php
@@ -31,6 +31,7 @@ $router->get('/sistemas/dashboard',      [SistemasDashboard::class,    'index'],
 $router->get('/cumplimiento/dashboard',  [CumplimientoDashboard::class,'index'], ['middleware'=>['auth','role:cumplimiento,administrador']]);
 $router->get('/administrador/dashboard', [AdminDashboard::class,       'index'], ['middleware'=>['auth','role:administrador']]);
 $router->get('/comercial/entidades/ver', [EntidadesController::class, 'show'], ['middleware'=>['auth','role:comercial,administrador']]);
+$router->get('/comercial/entidades/{id}/show', [EntidadesController::class, 'showJson'], ['middleware'=>['auth','role:comercial']]);
 
 // ---------- Comercial → Entidades (CRUD, auth + role) ----------
 $router->get('/comercial/entidades',           [EntidadesController::class, 'index'],      ['middleware'=>['auth','role:comercial,administrador']]);

--- a/public/css/comercial_style/entidades-cards.css
+++ b/public/css/comercial_style/entidades-cards.css
@@ -1,0 +1,297 @@
+/* Tarjetas de entidades (vista grid) */
+.ent-cards-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.ent-cards-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ent-cards-header__titles {
+  display: flex;
+  flex-direction: column;
+  gap: .35rem;
+}
+
+.ent-cards-header__summary {
+  color: #6b7280;
+  font-weight: 600;
+  font-size: .95rem;
+}
+
+.ent-cards-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.ent-cards-search {
+  display: flex;
+  flex-direction: column;
+  gap: .35rem;
+  min-width: min(320px, 100%);
+}
+
+.ent-cards-search__label {
+  font-weight: 600;
+  color: var(--text-body, #1f2937);
+}
+
+.ent-cards-search__group {
+  display: flex;
+  gap: .5rem;
+  align-items: center;
+}
+
+.ent-cards-search__group input[type="search"] {
+  flex: 1;
+  min-width: 0;
+  padding: .6rem .75rem;
+  border: 1px solid #d1d5db;
+  border-radius: .65rem;
+  background: #fff;
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+
+.ent-cards-search__group input[type="search"]:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(255, 102, 0, .12);
+  outline: none;
+}
+
+.ent-cards-search__help {
+  font-size: .8rem;
+  color: #9ca3af;
+}
+
+.ent-cards-empty {
+  padding: 1.2rem 1.5rem;
+  border-radius: 12px;
+  background: #fff7ed;
+  color: #9a3412;
+  border: 1px solid #fdba74;
+}
+
+.ent-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.ent-card-item {
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, .08);
+  padding: 1.25rem;
+  gap: 1rem;
+}
+
+.ent-card-item__header {
+  display: flex;
+  gap: .75rem;
+  align-items: center;
+}
+
+.ent-card-item__icon {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(255,102,0,.12), rgba(255,102,0,.28));
+  font-size: 1.8rem;
+}
+
+.ent-card-item__text {
+  display: flex;
+  flex-direction: column;
+  gap: .2rem;
+}
+
+.ent-card-item__title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--color-secondary, #1f2937);
+  margin: 0;
+}
+
+.ent-card-item__subtitle {
+  margin: 0;
+  color: #6b7280;
+  font-weight: 600;
+}
+
+.ent-card-item__body {
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+}
+
+.ent-card-item__details {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: .5rem;
+}
+
+.ent-card-item__details dt {
+  font-weight: 700;
+  color: var(--text-body, #1f2937);
+}
+
+.ent-card-item__details dd {
+  margin: 0;
+  color: #4b5563;
+}
+
+.ent-card-item__services {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+}
+
+.ent-card-item__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: .25rem .6rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, .12);
+  color: #1d4ed8;
+  font-size: .8rem;
+  font-weight: 700;
+}
+
+.ent-card-item__badge--empty {
+  background: #f3f4f6;
+  color: #6b7280;
+}
+
+.ent-card-item__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+  margin-top: auto;
+}
+
+.ent-card-item__action {
+  flex: 1 1 auto;
+  text-align: center;
+}
+
+.ent-card-item__delete {
+  flex: 1 1 auto;
+}
+
+/* Modal */
+.ent-card-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, .55);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 999;
+}
+
+.ent-card-modal[aria-hidden="false"] {
+  display: flex;
+}
+
+.ent-card-modal__dialog {
+  background: #fff;
+  border-radius: 18px;
+  max-width: min(680px, 100%);
+  width: 100%;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, .25);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.ent-card-modal__close {
+  align-self: flex-end;
+  background: transparent;
+  border: none;
+  font-size: 1.8rem;
+  cursor: pointer;
+  color: #6b7280;
+}
+
+.ent-card-modal__header {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.ent-card-modal__titles {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+
+.ent-card-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+}
+
+.ent-card-modal__details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: .75rem;
+}
+
+.ent-card-modal__details dt {
+  font-weight: 700;
+  color: var(--text-body, #1f2937);
+}
+
+.ent-card-modal__details dd {
+  margin: 0;
+  color: #4b5563;
+  white-space: pre-line;
+}
+
+.ent-card-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .ent-card-item__details {
+    grid-template-columns: 1fr;
+  }
+
+  .ent-card-item__footer {
+    flex-direction: column;
+  }
+
+  .ent-card-item__action,
+  .ent-card-item__delete {
+    width: 100%;
+  }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -36,24 +36,70 @@ function view(string $tpl, array $data=[]){
 // ---------------- Router + Middleware ----------------
 class Router {
   private $routes = ['GET'=>[], 'POST'=>[]];
-  public function get(string $path, $handler, array $opts = []){ $this->routes['GET'][$path]=[$handler,$opts]; }
-  public function post(string $path, $handler, array $opts = []){ $this->routes['POST'][$path]=[$handler,$opts]; }
+
+  public function get(string $path, $handler, array $opts = []): void {
+    $this->addRoute('GET', $path, $handler, $opts);
+  }
+
+  public function post(string $path, $handler, array $opts = []): void {
+    $this->addRoute('POST', $path, $handler, $opts);
+  }
+
+  private function addRoute(string $method, string $path, $handler, array $opts): void {
+    $hasParams = strpos($path, '{') !== false;
+    $pattern = null;
+    if ($hasParams) {
+      $pattern = '#^' . preg_replace('#\{([a-zA-Z_][a-zA-Z0-9_-]*)\}#', '(?P<$1>[^/]+)', $path) . '$#';
+    }
+    $this->routes[$method][] = [
+      'path' => $path,
+      'handler' => $handler,
+      'opts' => $opts,
+      'pattern' => $pattern,
+      'hasParams' => $hasParams,
+    ];
+  }
 
   public function dispatch(){
     $m = $_SERVER['REQUEST_METHOD'] ?? 'GET';
     $uri = strtok($_SERVER['REQUEST_URI'] ?? '/', '?') ?: '/';
-    if (!isset($this->routes[$m][$uri])) { http_response_code(404); echo "404"; return; }
-    [$handler, $opts] = $this->routes[$m][$uri];
+    $routes = $this->routes[$m] ?? [];
+    $matched = null;
+    $params = [];
+
+    foreach ($routes as $route) {
+      if ($route['path'] === $uri) {
+        $matched = $route;
+        break;
+      }
+      if ($route['hasParams'] && $route['pattern'] && preg_match($route['pattern'], $uri, $matches)) {
+        $matched = $route;
+        foreach ($matches as $key => $value) {
+          if (!is_int($key)) {
+            $params[] = $value;
+          }
+        }
+        break;
+      }
+    }
+
+    if (!$matched) { http_response_code(404); echo "404"; return; }
+
+    $handler = $matched['handler'];
+    $opts = $matched['opts'];
     $mwList = $opts['middleware'] ?? [];
     $callable = $this->toCallable($handler);
-    $pipeline = MiddlewareKernel::pipeline($mwList, $callable);
+    $runner = function() use ($callable, $params) {
+      return call_user_func_array($callable, $params);
+    };
+    $pipeline = MiddlewareKernel::pipeline($mwList, $runner);
     return $pipeline();
   }
 
   private function toCallable($h): callable {
     if (is_array($h) && is_string($h[0])) { // [Class, method]
       $obj = new $h[0]();
-      return function() use ($obj, $h){ return call_user_func([$obj, $h[1]]); };
+      return [$obj, $h[1]];
     }
     if (is_callable($h)) return $h;
     throw new \RuntimeException('Handler inválido');

--- a/public/js/entidades_cards.js
+++ b/public/js/entidades_cards.js
@@ -1,0 +1,106 @@
+(function(){
+  const modal = document.getElementById('ent-card-modal');
+  if (!modal) return;
+
+  const closeButtons = modal.querySelectorAll('.ent-card-modal__close');
+  const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  let lastFocus = null;
+
+  const setText = (selector, value, fallback) => {
+    const el = modal.querySelector(selector);
+    if (!el) return;
+    const text = value === null || value === undefined || value === '' ? (fallback ?? '—') : String(value);
+    el.textContent = text;
+  };
+
+  const openModal = () => {
+    lastFocus = document.activeElement;
+    modal.setAttribute('aria-hidden', 'false');
+    document.documentElement.style.overflow = 'hidden';
+    const focusable = modal.querySelectorAll(focusableSelectors);
+    if (focusable.length) {
+      focusable[0].focus();
+    }
+  };
+
+  const closeModal = () => {
+    modal.setAttribute('aria-hidden', 'true');
+    document.documentElement.style.overflow = '';
+    if (lastFocus && typeof lastFocus.focus === 'function') {
+      lastFocus.focus();
+    }
+  };
+
+  closeButtons.forEach(btn => btn.addEventListener('click', closeModal));
+  modal.addEventListener('click', event => {
+    if (event.target === modal) {
+      closeModal();
+    }
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && modal.getAttribute('aria-hidden') === 'false') {
+      closeModal();
+    }
+  });
+
+  function formatServicios(servicios) {
+    if (!Array.isArray(servicios)) {
+      return [];
+    }
+    return servicios.reduce((acc, item) => {
+      const label = item && typeof item === 'object'
+        ? (item.nombre_servicio ?? item.nombre ?? item.label ?? '')
+        : item;
+      const text = String(label ?? '').trim();
+      if (text !== '') {
+        acc.push(text);
+      }
+      return acc;
+    }, []);
+  }
+
+  async function loadEntity(id) {
+    try {
+      const response = await fetch(`/comercial/entidades/${encodeURIComponent(id)}/show`, {
+        headers: { 'Accept': 'application/json' }
+      });
+      if (!response.ok) {
+        throw new Error('Respuesta no válida');
+      }
+      const data = await response.json();
+      if (data && data.error) {
+        throw new Error(data.error);
+      }
+
+      setText('#ent-card-modal-title', data.nombre || 'Entidad');
+      setText('#ent-card-modal-segmento', data.segmento || 'No especificado');
+      const servicios = formatServicios(data.servicios || []);
+      setText('#ent-card-modal-serv-count', `${servicios.length} servicios`);
+      setText('#modal-ubicacion', data.ubicacion || 'No especificado');
+      setText('#modal-tipo', data.tipo || 'No especificado');
+      setText('#modal-ruc', data.ruc || '—');
+      setText('#modal-telefono-fijo', data.telefono_fijo || '—');
+      setText('#modal-telefono-movil', data.telefono_movil || '—');
+      setText('#modal-email', data.email || '—');
+      setText('#modal-notas', data.notas || '—');
+      setText('#modal-servicios', servicios.length ? servicios.join('\n') : 'Sin servicios registrados');
+      openModal();
+    } catch (error) {
+      console.error('No se pudo cargar la entidad', error);
+      setText('#modal-servicios', 'No se pudo cargar la información');
+      openModal();
+    }
+  }
+
+  document.addEventListener('click', event => {
+    const button = event.target.closest('[data-entity-id]');
+    if (!button) {
+      return;
+    }
+    const id = button.getAttribute('data-entity-id');
+    if (!id) {
+      return;
+    }
+    loadEntity(id);
+  });
+})();


### PR DESCRIPTION
## Summary
- add an accessible card-based entidades listing with dedicated styles and modal script
- expose a JSON detail endpoint for entidades and extend the router to accept path parameters

## Testing
- php -l app/Controllers/Comercial/EntidadesController.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d2e2c340248326883782a986c56694