### PR TITLE
Alinear creación y edición de entidades con DTO canónico

### DIFF
--- a/app/Controllers/Comercial/EntidadesController.php
+++ b/app/Controllers/Comercial/EntidadesController.php
@@ -138,7 +138,8 @@ final class EntidadesController
         }
 
         try {
-            $repo->create($res['data']);
+            $id = $repo->create($res['data']);
+            $repo->replaceServicios($id, $res['data']['servicios'] ?? array());
         } catch (\Throwable $e) {
             Logger::error($e, 'EntidadesController::create');
             http_response_code(500);

--- a/app/Views/comercial/entidades/_form.php
+++ b/app/Views/comercial/entidades/_form.php
@@ -13,13 +13,40 @@ $segmentosData = is_array($segmentos ?? null) ? $segmentos : [];
 $provSel = (int)($item['provincia_id'] ?? $old['provincia_id'] ?? 0);
 $cantSel = (int)($item['canton_id'] ?? $old['canton_id'] ?? 0);
 
-$val = static function (string $key, $default = '') use ($old, $item) {
+$aliases = [
+    'nit'            => 'ruc',
+    'telefono_fijo'  => 'telefono_fijo_1',
+    'telefono_fijo_1'=> 'telefono_fijo_1',
+    'telefono_movil' => 'telefono_movil',
+    'provincia_id'   => 'provincia_id',
+    'canton_id'      => 'canton_id',
+    'id_segmento'    => 'id_segmento',
+    'servicios'      => 'servicios',
+    'notas'          => 'notas',
+    'nombre'         => 'nombre',
+    'email'          => 'email',
+    'tipo_entidad'   => 'tipo_entidad',
+];
+
+$val = static function (string $key, $default = '') use ($old, $item, $aliases) {
     if (array_key_exists($key, $old)) {
         return $old[$key];
     }
 
     if (array_key_exists($key, $item)) {
         return $item[$key];
+    }
+
+    if (isset($aliases[$key])) {
+        $alias = $aliases[$key];
+        if ($alias !== $key) {
+            if (array_key_exists($alias, $old)) {
+                return $old[$alias];
+            }
+            if (array_key_exists($alias, $item)) {
+                return $item[$alias];
+            }
+        }
     }
 
     return $default;
@@ -30,6 +57,9 @@ if (!is_array($servSel)) {
     $servSel = [];
 }
 $servSel = array_map('intval', $servSel);
+if (empty($servSel) && isset($sel) && is_array($sel)) {
+    $servSel = array_map('intval', $sel);
+}
 
 $segmentoActual = (string)$val('id_segmento', '');
 $segmentOptions = ['' => '-- N/A --'];


### PR DESCRIPTION
## Summary
- normalizar y validar el formulario de entidades para producir el DTO canónico requerido
- reescribir el repositorio de entidades para usar columnas reales, sanitizar datos y registrar errores de PDO
- mantener la relación cooperativa_servicio coherente (Matrix exclusivo) y actualizar la UI para usar los nuevos nombres

## Testing
- php -l app/Services/Shared/ValidationService.php
- php -l app/Repositories/Comercial/EntidadRepository.php
- php -l app/Views/comercial/entidades/_form.php
- php -l app/Controllers/Comercial/EntidadesController.php

------
https://chatgpt.com/codex/tasks/task_e_68d5d4220bec83268aec9cd4c2d67ce6