### PR TITLE
Align entidades CRUD workflow with canonical DTO

### DIFF
--- a/app/Repositories/Comercial/EntidadRepository.php
+++ b/app/Repositories/Comercial/EntidadRepository.php
@@ -3,486 +3,377 @@ declare(strict_types=1);
 
 namespace App\Repositories\Comercial;
 
-use App\Repositories\BaseRepository;
 use PDO;
-use RuntimeException;
+use PDOException;
+use function Config\db;
 
-/**
- * Repositorio de Cooperativas (Comercial).
- * - Bindea tipos correctamente (STR/NULL, INT/NULL, BOOL)
- * - Provee helpers de segmentos, servicios y pivot de relación
- * - SELECT con alias que el formulario espera (ruc AS nit, estado)
- */
-final class EntidadRepository extends BaseRepository
+final class EntidadRepository
 {
-    private const T_COOP            = 'public.cooperativas';
-    private const COL_ID            = 'id_cooperativa';
-    private const COL_NOMBRE        = 'nombre';
-    private const COL_RUC           = 'ruc';
-    private const COL_TELF          = 'telefono';
-    private const COL_TFIJ          = 'telefono_fijo_1';
-    private const COL_TMOV          = 'telefono_movil';
-    private const COL_MAIL          = 'email';
-    private const COL_ACTV          = 'activa';
-    private const COL_PROV          = 'provincia_id';
-    private const COL_CANTON        = 'canton_id';
-    private const COL_TIPO          = 'tipo_entidad';
-    private const COL_SEGMENTO      = 'id_segmento';
-    private const COL_NOTAS         = 'notas';
+    private PDO $db;
+    private const TBL = 'public.cooperativas';
+    private const PK  = 'id_cooperativa';
 
-    private const T_SERV            = 'public.servicios';
-    private const COL_ID_SERV       = 'id_servicio';
-    private const COL_NOM_SERV      = 'nombre_servicio';
-    private const COL_SERV_ACTIVO   = 'activo';
-
-    private const T_SEG             = 'public.segmentos';
-    private const COL_ID_SEG        = 'id_segmento';
-    private const COL_NOM_SEG       = 'nombre_segmento';
-
-    private const T_PIVOT           = 'public.cooperativa_servicio';
-    private const PIV_COOP          = 'id_cooperativa';
-    private const PIV_SERV          = 'id_servicio';
-    private const PIV_ACTIVO        = 'activo';
+    public function __construct(?PDO $db = null)
+    {
+        $this->db = $db ?? db();
+    }
 
     /**
-     * Búsqueda paginada.
-     *
      * @return array{items:array<int,array<string,mixed>>, total:int, page:int, perPage:int}
      */
-    public function search(string $q, int $page, int $perPage): array
+    public function search(string $term, int $page, int $perPage): array
     {
         $page    = max(1, $page);
         $perPage = max(1, min(60, $perPage));
         $offset  = ($page - 1) * $perPage;
+        $term    = trim($term);
+        $like    = '%' . $term . '%';
 
-        $q     = trim($q);
-        $hasQ  = $q !== '' ? 1 : 0;
-        $qLike = '%' . $q . '%';
+        $countSql = <<<SQL
+            SELECT COUNT(*)
+            FROM public.cooperativas c
+            WHERE (:term = '')
+               OR (c.nombre ILIKE :like OR c.ruc ILIKE :like)
+        SQL;
 
-        $countSql = '
-            SELECT COUNT(*) AS total
-            FROM ' . self::T_COOP . ' c
-            WHERE (
-                :has_q = 0
-                OR (
-                    unaccent(lower(c.' . self::COL_NOMBRE . ')) LIKE unaccent(lower(:q_like))
-                    OR c.' . self::COL_RUC . ' LIKE :q_like
-                )
-            )
-        ';
-
-        $bindings = array(
-            ':has_q'  => array($hasQ, PDO::PARAM_INT),
-            ':q_like' => array($qLike, PDO::PARAM_STR),
-        );
-
-        try {
-            $countRow = $this->db->fetch($countSql, $bindings);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al contar entidades.', 0, $e);
-        }
-
-        $total = $countRow ? (int)$countRow['total'] : 0;
+        $countSt = $this->db->prepare($countSql);
+        $countSt->bindValue(':term', $term, PDO::PARAM_STR);
+        $countSt->bindValue(':like', $like, PDO::PARAM_STR);
+        $countSt->execute();
+        $total = (int)$countSt->fetchColumn();
 
         if ($total === 0) {
-            return array(
-                'items'   => array(),
+            return [
+                'items'   => [],
                 'total'   => 0,
                 'page'    => $page,
                 'perPage' => $perPage,
-            );
+            ];
         }
 
-        $sqlLines = array(
-            'SELECT',
-            '    c.' . self::COL_ID . ' AS id,',
-            '    c.' . self::COL_NOMBRE . ' AS nombre,',
-            '    c.' . self::COL_RUC . ' AS ruc,',
-            '    c.' . self::COL_TIPO . ' AS tipo_entidad,',
-            '    c.' . self::COL_SEGMENTO . ' AS id_segmento,',
-            '    seg.' . self::COL_NOM_SEG . ' AS segmento_nombre,',
-            '    COALESCE(c.' . self::COL_PROV . ', df.provincia_id) AS provincia_id,',
-            '    prov.nombre AS provincia_nombre,',
-            '    COALESCE(c.' . self::COL_CANTON . ', df.canton_id) AS canton_id,',
-            '    can.nombre AS canton_nombre,',
-            '    phone_data.telefonos_json,',
-            '    email_data.emails_json,',
-            '    svc.servicios_json,',
-            '    COALESCE(svc.servicios_count, 0) AS servicios_count',
-            'FROM ' . self::T_COOP . ' c',
-            'LEFT JOIN ' . self::T_SEG . ' seg',
-            '  ON seg.' . self::COL_ID_SEG . ' = c.' . self::COL_SEGMENTO,
-            'LEFT JOIN public.datos_facturacion df',
-            '  ON df.id_cooperativa = c.' . self::COL_ID,
-            'LEFT JOIN public.provincia prov',
-            '  ON prov.id = COALESCE(c.' . self::COL_PROV . ', df.provincia_id)',
-            'LEFT JOIN public.canton can',
-            '  ON can.id = COALESCE(c.' . self::COL_CANTON . ', df.canton_id)',
-            'LEFT JOIN LATERAL (',
-            '    SELECT json_agg(phone ORDER BY phone) AS telefonos_json',
-            '    FROM (',
-            '        SELECT DISTINCT phone',
-            '        FROM (',
-            "            SELECT NULLIF(TRIM(c." . self::COL_TELF . "), '') AS phone",
-            "            UNION ALL",
-            "            SELECT NULLIF(TRIM(c." . self::COL_TFIJ . "), '')",
-            "            UNION ALL",
-            "            SELECT NULLIF(TRIM(c." . self::COL_TMOV . "), '')",
-            '        ) AS raw',
-            '        WHERE phone IS NOT NULL',
-            '    ) AS phones',
-            ') AS phone_data ON TRUE',
-            'LEFT JOIN LATERAL (',
-            '    SELECT json_agg(email ORDER BY email) AS emails_json',
-            '    FROM (',
-            '        SELECT DISTINCT email',
-            '        FROM (',
-            "            SELECT NULLIF(TRIM(c." . self::COL_MAIL . "), '') AS email",
-            '        ) AS raw',
-            '        WHERE email IS NOT NULL',
-            '    ) AS emails',
-            ') AS email_data ON TRUE',
-            'LEFT JOIN LATERAL (',
-            '    SELECT',
-            '        json_agg(nombre_servicio ORDER BY nombre_servicio) AS servicios_json,',
-            '        COUNT(*) AS servicios_count',
-            '    FROM (',
-            '        SELECT DISTINCT s.' . self::COL_NOM_SERV . ' AS nombre_servicio',
-            '        FROM ' . self::T_PIVOT . ' cs',
-            '        JOIN ' . self::T_SERV . ' s ON s.' . self::COL_ID_SERV . ' = cs.' . self::PIV_SERV,
-            '        WHERE cs.' . self::PIV_COOP . ' = c.' . self::COL_ID,
-            '          AND cs.' . self::PIV_ACTIVO . ' = true',
-            '    ) AS svc_names',
-            ') AS svc ON TRUE',
-            'WHERE (',
-            '    :has_q = 0',
-            '    OR (',
-            '        unaccent(lower(c.' . self::COL_NOMBRE . ')) LIKE unaccent(lower(:q_like))',
-            '        OR c.' . self::COL_RUC . ' LIKE :q_like',
-            '    )',
-            ')',
-            'ORDER BY c.' . self::COL_NOMBRE,
-            'LIMIT :limit OFFSET :offset',
-        );
+        $sql = <<<SQL
+            SELECT
+                c.id_cooperativa AS id,
+                c.nombre,
+                NULLIF(c.ruc, '') AS ruc,
+                NULLIF(c.telefono_fijo_1, '') AS telefono_fijo_1,
+                NULLIF(c.telefono_movil, '') AS telefono_movil,
+                NULLIF(c.email, '') AS email,
+                c.provincia_id,
+                c.canton_id,
+                c.tipo_entidad,
+                c.id_segmento,
+                seg.nombre_segmento AS segmento_nombre,
+                prov.nombre AS provincia_nombre,
+                cant.nombre AS canton_nombre,
+                svc.nombres AS servicios_json,
+                COALESCE(svc.total, 0) AS servicios_count
+            FROM public.cooperativas c
+            LEFT JOIN public.segmentos seg ON seg.id_segmento = c.id_segmento
+            LEFT JOIN public.provincias prov ON prov.id_provincia = c.provincia_id
+            LEFT JOIN public.cantones cant ON cant.id_canton = c.canton_id
+            LEFT JOIN LATERAL (
+                SELECT json_agg(s.nombre_servicio ORDER BY s.nombre_servicio) AS nombres,
+                       COUNT(*) AS total
+                FROM public.cooperativa_servicio cs
+                JOIN public.servicios s ON s.id_servicio = cs.id_servicio
+                WHERE cs.id_cooperativa = c.id_cooperativa AND cs.activo = TRUE
+            ) svc ON TRUE
+            WHERE (:term = '')
+               OR (c.nombre ILIKE :like OR c.ruc ILIKE :like)
+            ORDER BY c.nombre
+            LIMIT :limit OFFSET :offset
+        SQL;
 
-        $sql = implode("\n", $sqlLines);
+        $st = $this->db->prepare($sql);
+        $st->bindValue(':term', $term, PDO::PARAM_STR);
+        $st->bindValue(':like', $like, PDO::PARAM_STR);
+        $st->bindValue(':limit', $perPage, PDO::PARAM_INT);
+        $st->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $st->execute();
+        $rows = $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
 
-        $queryParams = $bindings;
-        $queryParams[':limit']  = array($perPage, PDO::PARAM_INT);
-        $queryParams[':offset'] = array($offset, PDO::PARAM_INT);
-
-        try {
-            $items = $this->db->fetchAll($sql, $queryParams);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al buscar entidades.', 0, $e);
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = [
+                'id'               => (int)$row['id'],
+                'nombre'           => (string)$row['nombre'],
+                'ruc'              => $row['ruc'] !== null ? (string)$row['ruc'] : null,
+                'segmento_nombre'  => $row['segmento_nombre'] !== null ? (string)$row['segmento_nombre'] : null,
+                'provincia_nombre' => $row['provincia_nombre'] !== null ? (string)$row['provincia_nombre'] : null,
+                'canton_nombre'    => $row['canton_nombre'] !== null ? (string)$row['canton_nombre'] : null,
+                'telefonos'        => $this->listFromValues([
+                    $row['telefono_fijo_1'] ?? null,
+                    $row['telefono_movil'] ?? null,
+                ]),
+                'emails'           => $this->listFromValues([$row['email'] ?? null]),
+                'servicios'        => $this->decodeJsonList($row['servicios_json'] ?? null),
+                'servicios_count'  => (int)$row['servicios_count'],
+                'tipo_entidad'     => $row['tipo_entidad'] !== null ? (string)$row['tipo_entidad'] : null,
+                'id_segmento'      => $row['id_segmento'] !== null ? (int)$row['id_segmento'] : null,
+                'provincia_id'     => $row['provincia_id'] !== null ? (int)$row['provincia_id'] : null,
+                'canton_id'        => $row['canton_id'] !== null ? (int)$row['canton_id'] : null,
+            ];
         }
 
-        $items = $this->hydrateListado($items);
-
-        return array(
+        return [
             'items'   => $items,
             'total'   => $total,
             'page'    => $page,
             'perPage' => $perPage,
-        );
+        ];
     }
 
     public function findById(int $id): ?array
     {
-        $sql = '
+        $sql = <<<SQL
             SELECT
-                ' . self::COL_ID . '    AS id_cooperativa,
-                ' . self::COL_NOMBRE . '     AS nombre,
-                ' . self::COL_RUC . '        AS nit,
-                ' . self::COL_TFIJ . '      AS telefono_fijo_1,
-                ' . self::COL_TMOV . '       AS telefono_movil,
-                ' . self::COL_MAIL . '      AS email,
-                ' . self::COL_PROV . '       AS provincia_id,
-                ' . self::COL_CANTON . '     AS canton_id,
-                ' . self::COL_TIPO . '       AS tipo_entidad,
-                ' . self::COL_SEGMENTO . '   AS id_segmento,
-                ' . self::COL_NOTAS . '      AS notas,
-                ' . self::COL_ACTV . '     AS activa,
-                CASE WHEN ' . self::COL_ACTV . ' THEN \'activo\' ELSE \'inactivo\' END AS estado
-            FROM ' . self::T_COOP . '
-            WHERE ' . self::COL_ID . ' = :id
+                c.id_cooperativa AS id,
+                c.nombre,
+                NULLIF(c.ruc, '') AS ruc,
+                NULLIF(c.telefono_fijo_1, '') AS telefono_fijo_1,
+                NULLIF(c.telefono_movil, '') AS telefono_movil,
+                NULLIF(c.email, '') AS email,
+                c.provincia_id,
+                c.canton_id,
+                c.tipo_entidad,
+                c.id_segmento,
+                NULLIF(c.notas, '') AS notas
+            FROM public.cooperativas c
+            WHERE c.id_cooperativa = :id
             LIMIT 1
-        ';
+        SQL;
 
-        try {
-            $row = $this->db->fetch($sql, array(':id' => array($id, PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener la entidad.', 0, $e);
+        $st = $this->db->prepare($sql);
+        $st->bindValue(':id', $id, PDO::PARAM_INT);
+        $st->execute();
+        $row = $st->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
         }
 
-        return $row ?: null;
+        $row['servicios'] = $this->serviciosDeEntidad($id);
+
+        return $row;
     }
 
     public function findDetalles(int $id): ?array
     {
-        $sql = '
-        SELECT
-            c.id_cooperativa                                        AS id_entidad,
-            c.nombre,
-            NULLIF(c.ruc, ' . "''" . ')                             AS ruc,
-            NULLIF(c.telefono_fijo_1, ' . "''" . ')                  AS telefono_fijo_1,
-            NULLIF(c.telefono_movil, ' . "''" . ')                   AS telefono_movil,
-            NULLIF(c.email, ' . "''" . ')                            AS email,
-            COALESCE(c.provincia_id, df.provincia_id)               AS provincia_id,
-            COALESCE(c.canton_id, df.canton_id)                     AS canton_id,
-            prov.nombre                                             AS provincia,
-            can.nombre                                              AS canton,
-            c.tipo_entidad,
-            c.id_segmento,
-            seg.nombre_segmento                                     AS segmento_nombre,
-            c.notas
-        FROM public.cooperativas c
-        LEFT JOIN public.datos_facturacion df ON df.id_cooperativa = c.id_cooperativa
-        LEFT JOIN public.provincia prov ON prov.id = COALESCE(c.provincia_id, df.provincia_id)
-        LEFT JOIN public.canton    can  ON can.id = COALESCE(c.canton_id, df.canton_id)
-        LEFT JOIN public.segmentos seg ON seg.id_segmento = c.id_segmento
-        WHERE c.id_cooperativa = :id
-        LIMIT 1
-        ';
+        $sql = <<<SQL
+            SELECT
+                c.id_cooperativa AS id_entidad,
+                c.nombre,
+                NULLIF(c.ruc, '') AS ruc,
+                NULLIF(c.telefono_fijo_1, '') AS telefono_fijo_1,
+                NULLIF(c.telefono_movil, '') AS telefono_movil,
+                NULLIF(c.email, '') AS email,
+                c.provincia_id,
+                c.canton_id,
+                prov.nombre AS provincia,
+                cant.nombre AS canton,
+                c.tipo_entidad,
+                c.id_segmento,
+                seg.nombre_segmento AS segmento_nombre,
+                NULLIF(c.notas, '') AS notas
+            FROM public.cooperativas c
+            LEFT JOIN public.provincias prov ON prov.id_provincia = c.provincia_id
+            LEFT JOIN public.cantones cant ON cant.id_canton = c.canton_id
+            LEFT JOIN public.segmentos seg ON seg.id_segmento = c.id_segmento
+            WHERE c.id_cooperativa = :id
+            LIMIT 1
+        SQL;
 
-        try {
-            $row = $this->db->fetch($sql, array(':id' => array($id, PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener el detalle de la entidad.', 0, $e);
-        }
+        $st = $this->db->prepare($sql);
+        $st->bindValue(':id', $id, PDO::PARAM_INT);
+        $st->execute();
+        $row = $st->fetch(PDO::FETCH_ASSOC);
 
         return $row ?: null;
     }
 
+    /**
+     * @return array<int,array{id_servicio:int,nombre_servicio:string}>
+     */
     public function serviciosActivos(int $id): array
     {
-        $sql = '
-        SELECT s.id_servicio, s.nombre_servicio
-        FROM public.cooperativa_servicio cs
-        JOIN public.servicios s ON s.id_servicio = cs.id_servicio
-        WHERE cs.id_cooperativa = :id AND cs.activo = true
-        ORDER BY s.nombre_servicio
-        ';
+        $sql = <<<SQL
+            SELECT s.id_servicio, s.nombre_servicio
+            FROM public.cooperativa_servicio cs
+            JOIN public.servicios s ON s.id_servicio = cs.id_servicio
+            WHERE cs.id_cooperativa = :id AND cs.activo = TRUE
+            ORDER BY s.nombre_servicio
+        SQL;
 
-        try {
-            return $this->db->fetchAll($sql, array(':id' => array($id, PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener los servicios activos.', 0, $e);
-        }
+        $st = $this->db->prepare($sql);
+        $st->bindValue(':id', $id, PDO::PARAM_INT);
+        $st->execute();
+        return $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
     }
 
-    /** Crear y devolver el id nuevo */
-    public function create(array $d): int
-    {
-        $sql = '
-            INSERT INTO ' . self::T_COOP . '
-                (
-                    ' . self::COL_NOMBRE . ',
-                    ' . self::COL_RUC . ',
-                    ' . self::COL_MAIL . ',
-                    ' . self::COL_PROV . ',
-                    ' . self::COL_CANTON . ',
-                    ' . self::COL_SEGMENTO . ',
-                    ' . self::COL_NOTAS . ',
-                    ' . self::COL_TIPO . '
-                )
-            VALUES
-                (
-                    :nombre,
-                    :ruc,
-                    :email,
-                    :provincia_id,
-                    :canton_id,
-                    :segmento_id,
-                    :notas,
-                    :tipo_entidad
-                )
-            RETURNING ' . self::COL_ID . ' AS id
-        ';
-
-        $params = array(
-            ':nombre'       => array($d['nombre'], PDO::PARAM_STR),
-            ':ruc'          => $this->nullableStringParam($d['ruc'] ?? $d['nit'] ?? ''),
-            ':email'        => $this->nullableStringParam($d['email'] ?? ''),
-            ':provincia_id' => $this->nullableIntParam($d['provincia_id'] ?? null),
-            ':canton_id'    => $this->nullableIntParam($d['canton_id'] ?? null),
-            ':segmento_id'  => $this->nullableIntParam($d['id_segmento'] ?? $d['segmento_id'] ?? null),
-            ':notas'        => $this->nullableStringParam($d['notas'] ?? ''),
-            ':tipo_entidad' => array(
-                isset($d['tipo_entidad']) && $d['tipo_entidad'] !== '' ? (string)$d['tipo_entidad'] : 'cooperativa',
-                PDO::PARAM_STR
-            ),
-        );
-
-        try {
-            $rows = $this->db->execute($sql, $params);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al crear la entidad.', 0, $e);
-        }
-
-        $row = is_array($rows) && isset($rows[0]) ? $rows[0] : null;
-        if (!$row || !isset($row['id'])) {
-            throw new RuntimeException('INSERT cooperativas no devolvió id');
-        }
-
-        return (int)$row['id'];
-    }
-
-    /** Actualizar */
-    public function update(int $id, array $d): void
-    {
-        $sql = '
-            UPDATE ' . self::T_COOP . ' SET
-                ' . self::COL_NOMBRE . '   = :nombre,
-                ' . self::COL_RUC . '      = :ruc,
-                ' . self::COL_TFIJ . '    = :tfijo,
-                ' . self::COL_TMOV . '     = :tmov,
-                ' . self::COL_MAIL . '    = :email,
-                ' . self::COL_PROV . '     = :prov,
-                ' . self::COL_CANTON . '   = :canton,
-                ' . self::COL_TIPO . '     = :tipo,
-                ' . self::COL_SEGMENTO . ' = :segmento,
-                ' . self::COL_NOTAS . '    = :notas,
-                ' . self::COL_ACTV . '   = :activa
-            WHERE ' . self::COL_ID . ' = :id
-        ';
-
-        $params = $this->buildEntidadParams($d);
-        $params[':id'] = array($id, PDO::PARAM_INT);
-
-        try {
-            $this->db->execute($sql, $params);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al actualizar la entidad.', 0, $e);
-        }
-    }
-
-    /** Eliminar */
-    public function delete(int $id): void
-    {
-        $sql = 'DELETE FROM ' . self::T_COOP . ' WHERE ' . self::COL_ID . ' = :id';
-        try {
-            $this->db->execute($sql, array(':id' => array($id, PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al eliminar la entidad.', 0, $e);
-        }
-    }
-
-    /** Catálogo de servicios activos */
+    /**
+     * @return array<int,array{id:int,nombre:string}>
+     */
     public function servicios(): array
     {
-        $sql = 'SELECT ' . self::COL_ID_SERV . ' AS id_servicio, ' . self::COL_NOM_SERV . ' AS nombre_servicio'
-                . ' FROM ' . self::T_SERV
-                . ' WHERE ' . self::COL_SERV_ACTIVO . ' = true'
-                . ' ORDER BY ' . self::COL_ID_SERV;
-        try {
-            return $this->db->fetchAll($sql);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener los servicios.', 0, $e);
-        }
+        $sql = <<<SQL
+            SELECT id_servicio AS id, nombre_servicio AS nombre
+            FROM public.servicios
+            WHERE activo = TRUE
+            ORDER BY nombre_servicio
+        SQL;
+
+        $st = $this->db->query($sql);
+        return $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
     }
 
-    /** Catálogo de segmentos (1..5) */
+    /**
+     * @return array<int,array{id:int,nombre:string}>
+     */
     public function segmentos(): array
     {
-        $sql = 'SELECT ' . self::COL_ID_SEG . ' AS id_segmento, ' . self::COL_NOM_SEG . ' AS nombre_segmento'
-                . ' FROM ' . self::T_SEG
-                . ' ORDER BY ' . self::COL_ID_SEG;
-        try {
-            return $this->db->fetchAll($sql);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener los segmentos.', 0, $e);
-        }
+        $sql = <<<SQL
+            SELECT id_segmento AS id, nombre_segmento AS nombre
+            FROM public.segmentos
+            ORDER BY id_segmento
+        SQL;
+
+        $st = $this->db->query($sql);
+        return $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
     }
 
-    /** IDs de servicios asignados a una entidad */
+    /**
+     * @return array<int,int>
+     */
     public function serviciosDeEntidad(int $id): array
     {
-        $sql = 'SELECT ' . self::PIV_SERV . ' AS id_servicio FROM ' . self::T_PIVOT . ' WHERE ' . self::PIV_COOP . ' = :id';
-        try {
-            $rows = $this->db->fetchAll($sql, array(':id' => array($id, PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener los servicios de la entidad.', 0, $e);
-        }
+        $sql = <<<SQL
+            SELECT id_servicio
+            FROM public.cooperativa_servicio
+            WHERE id_cooperativa = :id AND activo = TRUE
+            ORDER BY id_servicio
+        SQL;
 
-        $ids = array();
-        foreach ($rows as $row) {
-            if (isset($row['id_servicio'])) {
-                $ids[] = (int)$row['id_servicio'];
-            }
-        }
-        return $ids;
+        $st = $this->db->prepare($sql);
+        $st->bindValue(':id', $id, PDO::PARAM_INT);
+        $st->execute();
+        $rows = $st->fetchAll(PDO::FETCH_COLUMN);
+        return array_map('intval', $rows ?: []);
     }
 
-    /** Reemplazar relación servicios (Matrix=1 exclusivo) */
+    public function create(array $d): int
+    {
+        $sql = <<<SQL
+            INSERT INTO public.cooperativas
+                (nombre, ruc, telefono_fijo_1, telefono_movil, email,
+                 provincia_id, canton_id, tipo_entidad, id_segmento, notas)
+            VALUES
+                (:nombre, :ruc, :tfijo, :tmovil, :email,
+                 :prov, :canton, :tipo, :seg, :notas)
+            RETURNING id_cooperativa AS id
+        SQL;
+
+        $st = $this->db->prepare($sql);
+        $this->bindEntidadCommon($st, $d);
+        $st->execute();
+        $id = $st->fetchColumn();
+        return (int)$id;
+    }
+
+    public function update(int $id, array $d): void
+    {
+        $sql = <<<SQL
+            UPDATE public.cooperativas SET
+                nombre = :nombre,
+                ruc = :ruc,
+                telefono_fijo_1 = :tfijo,
+                telefono_movil = :tmovil,
+                email = :email,
+                provincia_id = :prov,
+                canton_id = :canton,
+                tipo_entidad = :tipo,
+                id_segmento = :seg,
+                notas = :notas
+            WHERE id_cooperativa = :id
+        SQL;
+
+        $st = $this->db->prepare($sql);
+        $this->bindEntidadCommon($st, $d);
+        $st->bindValue(':id', $id, PDO::PARAM_INT);
+        $st->execute();
+    }
+
     public function replaceServicios(int $id, array $ids): void
     {
         $ids = array_values(array_unique(array_map('intval', $ids)));
-
         if (in_array(1, $ids, true)) {
-            $ids = array(1);
+            $ids = [1];
         }
 
-        $this->db->begin();
+        $this->db->beginTransaction();
         try {
-            $this->db->execute('DELETE FROM ' . self::T_PIVOT . ' WHERE ' . self::PIV_COOP . ' = :id', array(
-                ':id' => array($id, PDO::PARAM_INT),
-            ));
+            $del = $this->db->prepare('DELETE FROM public.cooperativa_servicio WHERE id_cooperativa = :id');
+            $del->bindValue(':id', $id, PDO::PARAM_INT);
+            $del->execute();
 
-            if (!empty($ids)) {
-                $sql = '
-                    INSERT INTO ' . self::T_PIVOT . ' (' . self::PIV_COOP . ', ' . self::PIV_SERV . ', ' . self::PIV_ACTIVO . ')
-                    VALUES (:c, :s, true)
-                ';
+            if ($ids !== []) {
+                $ins = $this->db->prepare(
+                    'INSERT INTO public.cooperativa_servicio (id_cooperativa, id_servicio, activo, fecha_alta)
+                     VALUES (:id, :sid, TRUE, now())'
+                );
                 foreach ($ids as $sid) {
-                    $this->db->execute($sql, array(
-                        ':c' => array($id, PDO::PARAM_INT),
-                        ':s' => array($sid, PDO::PARAM_INT),
-                    ));
+                    $ins->bindValue(':id', $id, PDO::PARAM_INT);
+                    $ins->bindValue(':sid', $sid, PDO::PARAM_INT);
+                    $ins->execute();
                 }
             }
 
             $this->db->commit();
-        } catch (\Throwable $e) {
-            $this->db->rollBack();
-            throw new RuntimeException('Error al actualizar los servicios de la entidad.', 0, $e);
+        } catch (PDOException $e) {
+            if ($this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+            throw $e;
         }
     }
 
-    /**
-     * @param array<int,array<string,mixed>> $rows
-     * @return array<int,array<string,mixed>>
-     */
-    private function hydrateListado(array $rows): array
+    public function delete(int $id): void
     {
-        $hydrated = array();
+        $st = $this->db->prepare('DELETE FROM public.cooperativas WHERE id_cooperativa = :id');
+        $st->bindValue(':id', $id, PDO::PARAM_INT);
+        $st->execute();
+    }
 
-        foreach ($rows as $row) {
-            $id = isset($row['id']) ? (int)$row['id'] : 0;
+    private function bindEntidadCommon(\PDOStatement $st, array $d): void
+    {
+        $st->bindValue(':nombre', (string)$d['nombre'], PDO::PARAM_STR);
+        $this->bindNullableString($st, ':ruc', $d['ruc'] ?? null);
+        $this->bindNullableString($st, ':tfijo', $d['telefono_fijo_1'] ?? null);
+        $this->bindNullableString($st, ':tmovil', $d['telefono_movil'] ?? null);
+        $this->bindNullableString($st, ':email', $d['email'] ?? null);
+        $this->bindNullableInt($st, ':prov', $d['provincia_id'] ?? null);
+        $this->bindNullableInt($st, ':canton', $d['canton_id'] ?? null);
+        $this->bindNullableString($st, ':tipo', $d['tipo_entidad'] ?? null);
+        $this->bindNullableInt($st, ':seg', $d['id_segmento'] ?? null);
+        $this->bindNullableString($st, ':notas', $d['notas'] ?? null);
+    }
 
-            $telefonos = $this->decodeJsonList($row['telefonos_json'] ?? null);
-            $emails    = $this->decodeJsonList($row['emails_json'] ?? null);
-            $servicios = $this->decodeJsonList($row['servicios_json'] ?? null);
-
-            $hydrated[] = array(
-                'id'               => $id,
-                'nombre'           => isset($row['nombre']) ? (string)$row['nombre'] : '',
-                'ruc'              => isset($row['ruc']) ? (string)$row['ruc'] : null,
-                'segmento_nombre'  => isset($row['segmento_nombre']) ? (string)$row['segmento_nombre'] : null,
-                'provincia_nombre' => isset($row['provincia_nombre']) ? (string)$row['provincia_nombre'] : null,
-                'canton_nombre'    => isset($row['canton_nombre']) ? (string)$row['canton_nombre'] : null,
-                'telefonos'        => $telefonos,
-                'emails'           => $emails,
-                'servicios'        => $servicios,
-                'servicios_count'  => isset($row['servicios_count']) ? (int)$row['servicios_count'] : 0,
-                'tipo_entidad'     => isset($row['tipo_entidad']) ? (string)$row['tipo_entidad'] : null,
-                'id_segmento'      => isset($row['id_segmento']) ? (int)$row['id_segmento'] : null,
-                'provincia_id'     => isset($row['provincia_id']) && $row['provincia_id'] !== null ? (int)$row['provincia_id'] : null,
-                'canton_id'        => isset($row['canton_id']) && $row['canton_id'] !== null ? (int)$row['canton_id'] : null,
-            );
+    private function bindNullableInt(\PDOStatement $st, string $param, ?int $value): void
+    {
+        if ($value === null) {
+            $st->bindValue($param, null, PDO::PARAM_NULL);
+            return;
         }
+        $st->bindValue($param, $value, PDO::PARAM_INT);
+    }
 
-        return $hydrated;
+    private function bindNullableString(\PDOStatement $st, string $param, ?string $value): void
+    {
+        if ($value === null || $value === '') {
+            $st->bindValue($param, null, PDO::PARAM_NULL);
+            return;
+        }
+        $st->bindValue($param, $value, PDO::PARAM_STR);
     }
 
     /**
@@ -492,89 +383,37 @@ final class EntidadRepository extends BaseRepository
     private function decodeJsonList($json): array
     {
         if ($json === null || $json === '') {
-            return array();
+            return [];
         }
 
         if (is_array($json)) {
-            $list = $json;
+            $values = $json;
         } else {
             $decoded = json_decode((string)$json, true);
-            $list    = is_array($decoded) ? $decoded : array();
+            $values  = is_array($decoded) ? $decoded : [];
         }
 
-        $clean = array();
-        foreach ($list as $value) {
+        return $this->listFromValues($values);
+    }
+
+    /**
+     * @param array<int,mixed> $values
+     * @return array<int,string>
+     */
+    private function listFromValues(array $values): array
+    {
+        $list = [];
+        foreach ($values as $value) {
             if (!is_scalar($value)) {
                 continue;
             }
             $trimmed = trim((string)$value);
-            if ($trimmed === '') {
+            if ($trimmed === '' || in_array($trimmed, $list, true)) {
                 continue;
             }
-            if (!in_array($trimmed, $clean, true)) {
-                $clean[] = $trimmed;
-            }
+            $list[] = $trimmed;
         }
 
-        return $clean;
-    }
-    /**
-     * @param array<string,mixed> $d
-     * @return array<string,array{0:mixed,1:int}>
-     */
-    private function buildEntidadParams(array $d): array
-    {
-        $params = array(
-            ':nombre'  => array($d['nombre'], PDO::PARAM_STR),
-            ':ruc'     => $this->nullableStringParam($d['nit'] ?? ''),
-            ':tfijo'   => $this->nullableStringParam($d['telefono_fijo'] ?? ''),
-            ':tmov'    => $this->nullableStringParam($d['telefono_movil'] ?? ''),
-            ':email'   => $this->nullableStringParam($d['email'] ?? ''),
-            ':prov'    => $this->nullableIntParam($d['provincia_id'] ?? null),
-            ':canton'  => $this->nullableIntParam($d['canton_id'] ?? null),
-            ':tipo'    => array($d['tipo_entidad'], PDO::PARAM_STR),
-            ':segmento'=> $this->nullableIntParam($d['id_segmento'] ?? null),
-            ':notas'   => $this->nullableStringParam($d['notas'] ?? ''),
-            ':activa'  => array($this->resolveActiva($d), PDO::PARAM_BOOL),
-        );
-
-        return $params;
-    }
-
-    private function resolveActiva(array $d): bool
-    {
-        if (array_key_exists('activa', $d)) {
-            return (bool)$d['activa'];
-        }
-        $estado = isset($d['estado']) ? (string)$d['estado'] : 'activo';
-        return $estado === 'activo';
-    }
-
-    /**
-     * @param mixed $value
-     * @return array{0:mixed,1:int}
-     */
-    private function nullableStringParam($value): array
-    {
-        if ($value === null) {
-            return array(null, PDO::PARAM_NULL);
-        }
-        $value = (string)$value;
-        if ($value === '') {
-            return array(null, PDO::PARAM_NULL);
-        }
-        return array($value, PDO::PARAM_STR);
-    }
-
-    /**
-     * @param mixed $value
-     * @return array{0:mixed,1:int}
-     */
-    private function nullableIntParam($value): array
-    {
-        if ($value === null || $value === '') {
-            return array(null, PDO::PARAM_NULL);
-        }
-        return array((int)$value, PDO::PARAM_INT);
+        return $list;
     }
 }

--- a/app/Repositories/Shared/UbicacionesRepository.php
+++ b/app/Repositories/Shared/UbicacionesRepository.php
@@ -11,7 +11,7 @@ final class UbicacionesRepository extends BaseRepository
     /** @return array<int, array{id:int, nombre:string}> */
     public function provincias(): array
     {
-        $sql = 'SELECT id, nombre FROM public.provincia ORDER BY nombre';
+        $sql = 'SELECT id_provincia AS id, nombre FROM public.provincias ORDER BY nombre';
         try {
             return $this->db->fetchAll($sql);
         } catch (\Throwable $e) {
@@ -22,7 +22,7 @@ final class UbicacionesRepository extends BaseRepository
     /** @return array<int, array{id:int, nombre:string}> */
     public function cantonesPorProvincia(int $provinciaId): array
     {
-        $sql = 'SELECT id, nombre FROM public.canton WHERE provincia_id = :p ORDER BY nombre';
+        $sql = 'SELECT id_canton AS id, nombre FROM public.cantones WHERE provincia_id = :p ORDER BY nombre';
         try {
             return $this->db->fetchAll($sql, array(':p' => array($provinciaId, \PDO::PARAM_INT)));
         } catch (\Throwable $e) {

--- a/app/Services/Comercial/ActualizarEntidadService.php
+++ b/app/Services/Comercial/ActualizarEntidadService.php
@@ -15,7 +15,8 @@ final class ActualizarEntidadService
     {
         $v = $this->val->validarEntidad($input);
         if (!$v['ok']) return ['ok'=>false, 'errors'=>$v['errors'], 'data'=>$v['data']];
-        $ok = $this->repo->update($id, $v['data']);
-        return ['ok'=>$ok];
+        $this->repo->update($id, $v['data']);
+        $this->repo->replaceServicios($id, $v['data']['servicios']);
+        return ['ok'=>true];
     }
 }

--- a/app/Services/Comercial/CrearEntidadService.php
+++ b/app/Services/Comercial/CrearEntidadService.php
@@ -16,6 +16,7 @@ final class CrearEntidadService
         $v = $this->val->validarEntidad($input);
         if (!$v['ok']) return ['ok'=>false, 'errors'=>$v['errors'], 'data'=>$v['data']];
         $id = $this->repo->create($v['data']);
+        $this->repo->replaceServicios($id, $v['data']['servicios']);
         return ['ok'=>true, 'id'=>$id];
     }
 }

--- a/app/Views/comercial/entidades/_form.php
+++ b/app/Views/comercial/entidades/_form.php
@@ -5,6 +5,26 @@ $errors = is_array($errors ?? null) ? $errors : [];
 $item   = is_array($item ?? null) ? $item : [];
 $old    = is_array($old ?? null) ? $old : [];
 
+$aliases = [
+    'nit'             => ['ruc'],
+    'ruc'             => ['nit'],
+    'telefono_fijo'   => ['telefono_fijo_1'],
+    'telefono_fijo_1' => ['telefono_fijo'],
+    'telefono_movil'  => [],
+    'id_segmento'     => ['segmento_id'],
+    'servicios'       => [],
+];
+
+$error = static function (string $key) use ($errors, $aliases) {
+    $keys = array_merge([$key], $aliases[$key] ?? []);
+    foreach ($keys as $alias) {
+        if (isset($errors[$alias])) {
+            return $errors[$alias];
+        }
+    }
+    return null;
+};
+
 $provincias = is_array($provincias ?? null) ? $provincias : [];
 $cantones   = is_array($cantones ?? null) ? $cantones : [];
 $servicios  = is_array($servicios ?? null) ? $servicios : [];
@@ -13,13 +33,17 @@ $segmentosData = is_array($segmentos ?? null) ? $segmentos : [];
 $provSel = (int)($item['provincia_id'] ?? $old['provincia_id'] ?? 0);
 $cantSel = (int)($item['canton_id'] ?? $old['canton_id'] ?? 0);
 
-$val = static function (string $key, $default = '') use ($old, $item) {
-    if (array_key_exists($key, $old)) {
-        return $old[$key];
+$val = static function (string $key, $default = '') use ($old, $item, $aliases) {
+    $keys = array_merge([$key], $aliases[$key] ?? []);
+    foreach ($keys as $alias) {
+        if (array_key_exists($alias, $old)) {
+            return $old[$alias];
+        }
     }
-
-    if (array_key_exists($key, $item)) {
-        return $item[$key];
+    foreach ($keys as $alias) {
+        if (array_key_exists($alias, $item)) {
+            return $item[$alias];
+        }
     }
 
     return $default;
@@ -54,13 +78,13 @@ if (!empty($segmentosData)) {
     ];
 }
 
-$tipoActual = (string)($item['tipo_entidad'] ?? $old['tipo_entidad'] ?? 'cooperativa');
+$tipoActual = (string)$val('tipo_entidad', 'cooperativa');
 $tiposEntidad = ['cooperativa', 'mutualista', 'sujeto_no_financiero', 'caja_ahorros', 'casa_valores'];
 ?>
 
 <div class="ent-form__grid grid grid-2">
   <label class="col-span-2">
-    Nombre * <?= isset($errors['nombre']) ? '<small class="text-error">' . $errors['nombre'] . '</small>' : '' ?>
+    Nombre * <?= ($error('nombre') !== null) ? '<small class="text-error">' . $error('nombre') . '</small>' : '' ?>
     <input
       type="text"
       name="nombre"
@@ -70,7 +94,7 @@ $tiposEntidad = ['cooperativa', 'mutualista', 'sujeto_no_financiero', 'caja_ahor
   </label>
 
   <label>
-    Cédula / RUC (10–13) <?= isset($errors['ruc']) ? '<small class="text-error">' . $errors['ruc'] . '</small>' : '' ?>
+    Cédula / RUC (10–13) <?= ($error('ruc') !== null) ? '<small class="text-error">' . $error('ruc') . '</small>' : '' ?>
     <input
       type="text"
       name="nit"
@@ -84,7 +108,7 @@ $tiposEntidad = ['cooperativa', 'mutualista', 'sujeto_no_financiero', 'caja_ahor
   </label>
 
   <label>
-    Teléfono fijo <?= isset($errors['telefono_fijo']) ? '<small class="text-error">' . $errors['telefono_fijo'] . '</small>' : '' ?>
+    Teléfono fijo <?= ($error('telefono_fijo') !== null) ? '<small class="text-error">' . $error('telefono_fijo') . '</small>' : '' ?>
     <input
       type="text"
       name="telefono_fijo"
@@ -98,7 +122,7 @@ $tiposEntidad = ['cooperativa', 'mutualista', 'sujeto_no_financiero', 'caja_ahor
   </label>
 
   <label class="col-span-2">
-    Celular <?= isset($errors['telefono_movil']) ? '<small class="text-error">' . $errors['telefono_movil'] . '</small>' : '' ?>
+    Celular <?= ($error('telefono_movil') !== null) ? '<small class="text-error">' . $error('telefono_movil') . '</small>' : '' ?>
     <input
       type="text"
       name="telefono_movil"
@@ -112,7 +136,7 @@ $tiposEntidad = ['cooperativa', 'mutualista', 'sujeto_no_financiero', 'caja_ahor
   </label>
 
   <label class="col-span-2">
-    Email <?= isset($errors['email']) ? '<small class="text-error">' . $errors['email'] . '</small>' : '' ?>
+    Email <?= ($error('email') !== null) ? '<small class="text-error">' . $error('email') . '</small>' : '' ?>
     <input
       type="email"
       name="email"
@@ -152,7 +176,7 @@ $tiposEntidad = ['cooperativa', 'mutualista', 'sujeto_no_financiero', 'caja_ahor
     </label>
 
     <label class="col-span-2">
-      Tipo de entidad
+      Tipo de entidad <?= ($error('tipo_entidad') !== null) ? '<small class="text-error">' . $error('tipo_entidad') . '</small>' : '' ?>
       <select id="tipo_entidad" name="tipo_entidad" class="select">
         <?php foreach ($tiposEntidad as $tipo): ?>
           <option value="<?= htmlspecialchars($tipo, ENT_QUOTES, 'UTF-8') ?>" <?= $tipo === $tipoActual ? 'selected' : '' ?>>
@@ -164,7 +188,7 @@ $tiposEntidad = ['cooperativa', 'mutualista', 'sujeto_no_financiero', 'caja_ahor
   </div>
 
   <label class="col-span-2">
-    Segmento (solo cooperativa)
+    Segmento (solo cooperativa) <?= ($error('id_segmento') !== null) ? '<small class="text-error">' . $error('id_segmento') . '</small>' : '' ?>
     <select name="id_segmento">
       <?php foreach ($segmentOptions as $valor => $label): ?>
         <option value="<?= htmlspecialchars($valor, ENT_QUOTES, 'UTF-8') ?>" <?= $segmentoActual === (string)$valor ? 'selected' : '' ?>>

--- a/config/routes.php
+++ b/config/routes.php
@@ -47,10 +47,10 @@ $router->get(
     [EntidadesController::class, 'index'],
     ['middleware'=>['auth','role:comercial']]
 );
-$router->get('/comercial/entidades/crear',     [EntidadesController::class, 'createForm'], ['middleware'=>['auth','role:comercial,administrador']]);
-$router->post('/comercial/entidades',          [EntidadesController::class, 'create'],     ['middleware'=>['auth','role:comercial,administrador']]);
-$router->get('/comercial/entidades/editar',    [EntidadesController::class, 'editForm'],   ['middleware'=>['auth','role:comercial,administrador']]);
-$router->post('/comercial/entidades/{id}',     [EntidadesController::class, 'update'],     ['middleware'=>['auth','role:comercial,administrador']]);
+$router->get ('/comercial/entidades/crear',        [EntidadesController::class, 'createForm'], ['middleware'=>['auth','role:comercial']]);
+$router->post('/comercial/entidades',              [EntidadesController::class, 'create'],     ['middleware'=>['auth','role:comercial']]);
+$router->get ('/comercial/entidades/{id}/edit',    [EntidadesController::class, 'editForm'],   ['middleware'=>['auth','role:comercial']]);
+$router->post('/comercial/entidades/{id}',         [EntidadesController::class, 'update'],     ['middleware'=>['auth','role:comercial']]);
 $router->post('/comercial/entidades/eliminar', [EntidadesController::class, 'delete'],     ['middleware'=>['auth','role:comercial,administrador']]);
 
 // 


### PR DESCRIPTION
## Summary
- normalize the comercial entidades controller around the canonical DTO with explicit validation and sanitized create/update flows
- replace the entidad repository with a single PDO-based implementation and refresh related services, validation, and views
- point ubicaciones queries to the real tables and adjust routes and form feedback to match the updated contract

## Testing
- php -l app/Controllers/Comercial/EntidadesController.php
- php -l app/Repositories/Comercial/EntidadRepository.php
- php -l app/Repositories/Shared/UbicacionesRepository.php
- php -l app/Services/Shared/ValidationService.php
- php -l app/Services/Comercial/CrearEntidadService.php
- php -l app/Services/Comercial/ActualizarEntidadService.php
- php -l config/routes.php

------
https://chatgpt.com/codex/tasks/task_e_68d5da78e9348326b34415d2a71b929c