### PR TITLE
Refactor comercial entidades CRUD to real schema

### DIFF
--- a/app/Repositories/Comercial/EntidadQueryRepository.php
+++ b/app/Repositories/Comercial/EntidadQueryRepository.php
@@ -1,0 +1,293 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Repositories\Comercial;
+
+use PDO;
+
+final class EntidadQueryRepository
+{
+    private PDO $db;
+
+    public function __construct(PDO $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @return array{items:array<int,array<string,mixed>>, total:int, page:int, perPage:int}
+     */
+    public function search(string $q, int $page, int $perPage): array
+    {
+        $page    = max(1, $page);
+        $perPage = max(1, min(60, $perPage));
+        $offset  = ($page - 1) * $perPage;
+        $term    = trim($q);
+
+        $where  = '';
+        $params = [];
+        if ($term !== '') {
+            $where = 'WHERE (c.nombre ILIKE :like_name OR c.ruc ILIKE :like_ruc)';
+            $like  = '%' . $term . '%';
+            $params[':like_name'] = $like;
+            $params[':like_ruc']  = $like;
+        }
+
+        $countSql = 'SELECT COUNT(*) FROM public.cooperativas c ' . $where;
+        $countStmt = $this->db->prepare($countSql);
+        $countStmt->execute($params);
+        $total = (int)$countStmt->fetchColumn();
+
+        if ($total === 0) {
+            return [
+                'items'   => [],
+                'total'   => 0,
+                'page'    => $page,
+                'perPage' => $perPage,
+            ];
+        }
+
+        $sql = "SELECT
+                    c.id_cooperativa AS id,
+                    c.nombre,
+                    c.ruc,
+                    c.tipo_entidad,
+                    c.id_segmento,
+                    seg.nombre AS segmento_nombre,
+                    c.provincia_id,
+                    prov.nombre AS provincia_nombre,
+                    c.canton_id,
+                    cant.nombre AS canton_nombre,
+                    c.telefono AS telefono_legacy,
+                    c.telefono_fijo_1,
+                    c.telefono_movil,
+                    c.email,
+                    json_agg(DISTINCT s.nombre ORDER BY s.nombre) AS servicios_json,
+                    COUNT(DISTINCT s.id_servicio) AS servicios_count
+                FROM public.cooperativas c
+                LEFT JOIN public.segmentos seg ON seg.id_segmento = c.id_segmento
+                LEFT JOIN public.provincias prov ON prov.id_provincia = c.provincia_id
+                LEFT JOIN public.cantones cant ON cant.id_canton = c.canton_id
+                LEFT JOIN public.cooperativa_servicio cs
+                       ON cs.id_cooperativa = c.id_cooperativa AND cs.activo = TRUE
+                LEFT JOIN public.servicios s ON s.id_servicio = cs.id_servicio
+                " . $where . "
+                GROUP BY c.id_cooperativa, c.nombre, c.ruc, c.tipo_entidad, c.id_segmento, seg.nombre,
+                         c.provincia_id, prov.nombre, c.canton_id, cant.nombre,
+                         c.telefono, c.telefono_fijo_1, c.telefono_movil, c.email
+                ORDER BY c.nombre
+                LIMIT :limit OFFSET :offset";
+
+        $stmt = $this->db->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value, PDO::PARAM_STR);
+        }
+        $stmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $items = [];
+        foreach ($rows as $row) {
+            $telefonos = $this->sanitizePhones([
+                $row['telefono_legacy'] ?? null,
+                $row['telefono_fijo_1'] ?? null,
+                $row['telefono_movil'] ?? null,
+            ]);
+            $emails = $this->sanitizeEmails([$row['email'] ?? null]);
+            $servicios = $this->decodeJsonList($row['servicios_json'] ?? null);
+            $serviciosCount = max(count($servicios), (int)($row['servicios_count'] ?? 0));
+
+            $items[] = [
+                'id'               => (int)$row['id'],
+                'nombre'           => (string)$row['nombre'],
+                'ruc'              => $row['ruc'] !== null ? (string)$row['ruc'] : null,
+                'tipo_entidad'     => $row['tipo_entidad'] !== null ? (string)$row['tipo_entidad'] : null,
+                'id_segmento'      => $row['id_segmento'] !== null ? (int)$row['id_segmento'] : null,
+                'segmento_nombre'  => $row['segmento_nombre'] !== null ? (string)$row['segmento_nombre'] : null,
+                'provincia_id'     => $row['provincia_id'] !== null ? (int)$row['provincia_id'] : null,
+                'provincia_nombre' => $row['provincia_nombre'] !== null ? (string)$row['provincia_nombre'] : null,
+                'canton_id'        => $row['canton_id'] !== null ? (int)$row['canton_id'] : null,
+                'canton_nombre'    => $row['canton_nombre'] !== null ? (string)$row['canton_nombre'] : null,
+                'telefonos'        => $telefonos,
+                'emails'           => $emails,
+                'servicios'        => $servicios,
+                'servicios_count'  => $serviciosCount,
+            ];
+        }
+
+        return [
+            'items'   => $items,
+            'total'   => $total,
+            'page'    => $page,
+            'perPage' => $perPage,
+        ];
+    }
+
+    public function findForEdit(int $id): ?array
+    {
+        $sql = "SELECT
+                    c.id_cooperativa AS id,
+                    c.nombre,
+                    c.ruc,
+                    c.telefono_fijo_1,
+                    c.telefono_movil,
+                    c.email,
+                    c.provincia_id,
+                    c.canton_id,
+                    c.tipo_entidad,
+                    c.id_segmento,
+                    c.notas
+                FROM public.cooperativas c
+                WHERE c.id_cooperativa = :id
+                LIMIT 1";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row) {
+            return null;
+        }
+
+        $row['servicios'] = $this->servicioIds($id);
+        return $row;
+    }
+
+    public function findDetalles(int $id): ?array
+    {
+        $sql = "SELECT
+                    c.id_cooperativa AS id,
+                    c.nombre,
+                    c.ruc,
+                    c.telefono_fijo_1,
+                    c.telefono_movil,
+                    c.email,
+                    c.tipo_entidad,
+                    c.id_segmento,
+                    seg.nombre AS segmento_nombre,
+                    c.provincia_id,
+                    prov.nombre AS provincia,
+                    c.canton_id,
+                    cant.nombre AS canton,
+                    c.notas
+                FROM public.cooperativas c
+                LEFT JOIN public.segmentos seg ON seg.id_segmento = c.id_segmento
+                LEFT JOIN public.provincias prov ON prov.id_provincia = c.provincia_id
+                LEFT JOIN public.cantones cant ON cant.id_canton = c.canton_id
+                WHERE c.id_cooperativa = :id
+                LIMIT 1";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    /** @return array<int,array{id:int,nombre:string}> */
+    public function segmentos(): array
+    {
+        $stmt = $this->db->query('SELECT id_segmento AS id, nombre FROM public.segmentos ORDER BY nombre');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /** @return array<int,array{id:int,nombre:string}> */
+    public function servicios(): array
+    {
+        $stmt = $this->db->query('SELECT id_servicio AS id, nombre FROM public.servicios ORDER BY nombre');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /** @return array<int,array{id:int,nombre:string}> */
+    public function serviciosActivos(int $id): array
+    {
+        $sql = "SELECT s.id_servicio AS id, s.nombre
+                FROM public.cooperativa_servicio cs
+                JOIN public.servicios s ON s.id_servicio = cs.id_servicio
+                WHERE cs.id_cooperativa = :id AND cs.activo = TRUE
+                ORDER BY s.nombre";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':id' => $id]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /** @return array<int,int> */
+    public function servicioIds(int $id): array
+    {
+        $sql = "SELECT cs.id_servicio
+                FROM public.cooperativa_servicio cs
+                WHERE cs.id_cooperativa = :id
+                ORDER BY cs.id_servicio";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':id' => $id]);
+        $ids = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $value) {
+            $ids[] = (int)$value;
+        }
+        return $ids;
+    }
+
+    /** @param array<int|string|null> $phones */
+    private function sanitizePhones(array $phones): array
+    {
+        $clean = [];
+        foreach ($phones as $phone) {
+            if ($phone === null) {
+                continue;
+            }
+            $digits = preg_replace('/\D+/', '', (string)$phone);
+            if ($digits === '') {
+                continue;
+            }
+            if (!in_array($digits, $clean, true)) {
+                $clean[] = $digits;
+            }
+        }
+        return $clean;
+    }
+
+    /** @param array<int|string|null> $emails */
+    private function sanitizeEmails(array $emails): array
+    {
+        $clean = [];
+        foreach ($emails as $email) {
+            if ($email === null) {
+                continue;
+            }
+            $trimmed = trim((string)$email);
+            if ($trimmed === '') {
+                continue;
+            }
+            if (!in_array($trimmed, $clean, true)) {
+                $clean[] = $trimmed;
+            }
+        }
+        return $clean;
+    }
+
+    /**
+     * @param mixed $json
+     * @return array<int,string>
+     */
+    private function decodeJsonList($json): array
+    {
+        if (!is_string($json) || $json === '') {
+            return [];
+        }
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+        $list = [];
+        foreach ($decoded as $value) {
+            if (!is_scalar($value)) {
+                continue;
+            }
+            $trimmed = trim((string)$value);
+            if ($trimmed === '') {
+                continue;
+            }
+            if (!in_array($trimmed, $list, true)) {
+                $list[] = $trimmed;
+            }
+        }
+        return $list;
+    }
+}

--- a/app/Repositories/Comercial/EntidadRepository.php
+++ b/app/Repositories/Comercial/EntidadRepository.php
@@ -3,578 +3,120 @@ declare(strict_types=1);
 
 namespace App\Repositories\Comercial;
 
-use App\Repositories\BaseRepository;
 use PDO;
-use RuntimeException;
 
-/**
- * Repositorio de Cooperativas (Comercial).
- * - Bindea tipos correctamente (STR/NULL, INT/NULL, BOOL)
- * - Provee helpers de segmentos, servicios y pivot de relación
- * - SELECT con alias que el formulario espera (ruc AS nit, estado)
- */
-final class EntidadRepository extends BaseRepository
+final class EntidadRepository
 {
-    private const T_COOP            = 'public.cooperativas';
-    private const COL_ID            = 'id_cooperativa';
-    private const COL_NOMBRE        = 'nombre';
-    private const COL_RUC           = 'ruc';
-    private const COL_TELF          = 'telefono';
-    private const COL_TFIJ          = 'telefono_fijo_1';
-    private const COL_TMOV          = 'telefono_movil';
-    private const COL_MAIL          = 'email';
-    private const COL_ACTV          = 'activa';
-    private const COL_PROV          = 'provincia_id';
-    private const COL_CANTON        = 'canton_id';
-    private const COL_TIPO          = 'tipo_entidad';
-    private const COL_SEGMENTO      = 'id_segmento';
-    private const COL_NOTAS         = 'notas';
+    private PDO $db;
+    private const TBL = 'public.cooperativas';
+    private const PK  = 'id_cooperativa';
 
-    private const T_SERV            = 'public.servicios';
-    private const COL_ID_SERV       = 'id_servicio';
-    private const COL_NOM_SERV      = 'nombre_servicio';
-    private const COL_SERV_ACTIVO   = 'activo';
+    public function __construct(PDO $db) { $this->db = $db; }
 
-    private const T_SEG             = 'public.segmentos';
-    private const COL_ID_SEG        = 'id_segmento';
-    private const COL_NOM_SEG       = 'nombre_segmento';
-
-    private const T_PIVOT           = 'public.cooperativa_servicio';
-    private const PIV_COOP          = 'id_cooperativa';
-    private const PIV_SERV          = 'id_servicio';
-    private const PIV_ACTIVO        = 'activo';
-
-    /**
-     * Búsqueda paginada.
-     *
-     * @return array{items:array<int,array<string,mixed>>, total:int, page:int, perPage:int}
-     */
-    public function search(string $q, int $page, int $perPage): array
-    {
-        $page    = max(1, $page);
-        $perPage = max(1, min(60, $perPage));
-        $offset  = ($page - 1) * $perPage;
-
-        $q     = trim($q);
-        $hasQ  = $q !== '' ? 1 : 0;
-        $qLike = '%' . $q . '%';
-
-        $countSql = '
-            SELECT COUNT(*) AS total
-            FROM ' . self::T_COOP . ' c
-            WHERE (
-                :has_q = 0
-                OR (
-                    unaccent(lower(c.' . self::COL_NOMBRE . ')) LIKE unaccent(lower(:q_like))
-                    OR c.' . self::COL_RUC . ' LIKE :q_like
-                )
-            )
-        ';
-
-        $bindings = array(
-            ':has_q'  => array($hasQ, PDO::PARAM_INT),
-            ':q_like' => array($qLike, PDO::PARAM_STR),
-        );
-
-        try {
-            $countRow = $this->db->fetch($countSql, $bindings);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al contar entidades.', 0, $e);
-        }
-
-        $total = $countRow ? (int)$countRow['total'] : 0;
-
-        if ($total === 0) {
-            return array(
-                'items'   => array(),
-                'total'   => 0,
-                'page'    => $page,
-                'perPage' => $perPage,
-            );
-        }
-
-        $sqlLines = array(
-            'SELECT',
-            '    c.' . self::COL_ID . ' AS id,',
-            '    c.' . self::COL_NOMBRE . ' AS nombre,',
-            '    c.' . self::COL_RUC . ' AS ruc,',
-            '    c.' . self::COL_TIPO . ' AS tipo_entidad,',
-            '    c.' . self::COL_SEGMENTO . ' AS id_segmento,',
-            '    seg.' . self::COL_NOM_SEG . ' AS segmento_nombre,',
-            '    COALESCE(c.' . self::COL_PROV . ', df.provincia_id) AS provincia_id,',
-            '    prov.nombre AS provincia_nombre,',
-            '    COALESCE(c.' . self::COL_CANTON . ', df.canton_id) AS canton_id,',
-            '    can.nombre AS canton_nombre,',
-            '    phone_data.telefonos_json,',
-            '    email_data.emails_json,',
-            '    svc.servicios_json,',
-            '    COALESCE(svc.servicios_count, 0) AS servicios_count',
-            'FROM ' . self::T_COOP . ' c',
-            'LEFT JOIN ' . self::T_SEG . ' seg',
-            '  ON seg.' . self::COL_ID_SEG . ' = c.' . self::COL_SEGMENTO,
-            'LEFT JOIN public.datos_facturacion df',
-            '  ON df.id_cooperativa = c.' . self::COL_ID,
-            'LEFT JOIN public.provincia prov',
-            '  ON prov.id = COALESCE(c.' . self::COL_PROV . ', df.provincia_id)',
-            'LEFT JOIN public.canton can',
-            '  ON can.id = COALESCE(c.' . self::COL_CANTON . ', df.canton_id)',
-            'LEFT JOIN LATERAL (',
-            '    SELECT json_agg(phone ORDER BY phone) AS telefonos_json',
-            '    FROM (',
-            '        SELECT DISTINCT phone',
-            '        FROM (',
-            "            SELECT NULLIF(TRIM(c." . self::COL_TELF . "), '') AS phone",
-            "            UNION ALL",
-            "            SELECT NULLIF(TRIM(c." . self::COL_TFIJ . "), '')",
-            "            UNION ALL",
-            "            SELECT NULLIF(TRIM(c." . self::COL_TMOV . "), '')",
-            '        ) AS raw',
-            '        WHERE phone IS NOT NULL',
-            '    ) AS phones',
-            ') AS phone_data ON TRUE',
-            'LEFT JOIN LATERAL (',
-            '    SELECT json_agg(email ORDER BY email) AS emails_json',
-            '    FROM (',
-            '        SELECT DISTINCT email',
-            '        FROM (',
-            "            SELECT NULLIF(TRIM(c." . self::COL_MAIL . "), '') AS email",
-            '        ) AS raw',
-            '        WHERE email IS NOT NULL',
-            '    ) AS emails',
-            ') AS email_data ON TRUE',
-            'LEFT JOIN LATERAL (',
-            '    SELECT',
-            '        json_agg(nombre_servicio ORDER BY nombre_servicio) AS servicios_json,',
-            '        COUNT(*) AS servicios_count',
-            '    FROM (',
-            '        SELECT DISTINCT s.' . self::COL_NOM_SERV . ' AS nombre_servicio',
-            '        FROM ' . self::T_PIVOT . ' cs',
-            '        JOIN ' . self::T_SERV . ' s ON s.' . self::COL_ID_SERV . ' = cs.' . self::PIV_SERV,
-            '        WHERE cs.' . self::PIV_COOP . ' = c.' . self::COL_ID,
-            '          AND cs.' . self::PIV_ACTIVO . ' = true',
-            '    ) AS svc_names',
-            ') AS svc ON TRUE',
-            'WHERE (',
-            '    :has_q = 0',
-            '    OR (',
-            '        unaccent(lower(c.' . self::COL_NOMBRE . ')) LIKE unaccent(lower(:q_like))',
-            '        OR c.' . self::COL_RUC . ' LIKE :q_like',
-            '    )',
-            ')',
-            'ORDER BY c.' . self::COL_NOMBRE,
-            'LIMIT :limit OFFSET :offset',
-        );
-
-        $sql = implode("\n", $sqlLines);
-
-        $queryParams = $bindings;
-        $queryParams[':limit']  = array($perPage, PDO::PARAM_INT);
-        $queryParams[':offset'] = array($offset, PDO::PARAM_INT);
-
-        try {
-            $items = $this->db->fetchAll($sql, $queryParams);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al buscar entidades.', 0, $e);
-        }
-
-        $items = $this->hydrateListado($items);
-
-        return array(
-            'items'   => $items,
-            'total'   => $total,
-            'page'    => $page,
-            'perPage' => $perPage,
-        );
-    }
-
-    public function findById(int $id): ?array
-    {
-        $sql = '
-            SELECT
-                ' . self::COL_ID . '    AS id_cooperativa,
-                ' . self::COL_NOMBRE . '     AS nombre,
-                ' . self::COL_RUC . '        AS nit,
-                ' . self::COL_TFIJ . '      AS telefono_fijo_1,
-                ' . self::COL_TMOV . '       AS telefono_movil,
-                ' . self::COL_MAIL . '      AS email,
-                ' . self::COL_PROV . '       AS provincia_id,
-                ' . self::COL_CANTON . '     AS canton_id,
-                ' . self::COL_TIPO . '       AS tipo_entidad,
-                ' . self::COL_SEGMENTO . '   AS id_segmento,
-                ' . self::COL_NOTAS . '      AS notas,
-                ' . self::COL_ACTV . '     AS activa,
-                CASE WHEN ' . self::COL_ACTV . ' THEN \'activo\' ELSE \'inactivo\' END AS estado
-            FROM ' . self::T_COOP . '
-            WHERE ' . self::COL_ID . ' = :id
-            LIMIT 1
-        ';
-
-        try {
-            $row = $this->db->fetch($sql, array(':id' => array($id, PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener la entidad.', 0, $e);
-        }
-
+    public function findById(int $id): ?array {
+        $sql = "SELECT
+                  c.".self::PK." AS id,
+                  c.nombre, c.ruc, c.telefono_fijo_1, c.telefono_movil, c.email,
+                  c.provincia_id, c.canton_id, c.tipo_entidad, c.id_segmento, c.notas
+                FROM ".self::TBL." c
+                WHERE c.".self::PK." = :id
+                LIMIT 1";
+        $st = $this->db->prepare($sql);
+        $st->execute([':id'=>$id]);
+        $row = $st->fetch(PDO::FETCH_ASSOC);
         return $row ?: null;
     }
 
-    public function findDetalles(int $id): ?array
-    {
-        $sql = '
-        SELECT
-            c.id_cooperativa                                        AS id_entidad,
-            c.nombre,
-            NULLIF(c.ruc, ' . "''" . ')                             AS ruc,
-            NULLIF(c.telefono_fijo_1, ' . "''" . ')                  AS telefono_fijo_1,
-            NULLIF(c.telefono_movil, ' . "''" . ')                   AS telefono_movil,
-            NULLIF(c.email, ' . "''" . ')                            AS email,
-            COALESCE(c.provincia_id, df.provincia_id)               AS provincia_id,
-            COALESCE(c.canton_id, df.canton_id)                     AS canton_id,
-            prov.nombre                                             AS provincia,
-            can.nombre                                              AS canton,
-            c.tipo_entidad,
-            c.id_segmento,
-            seg.nombre_segmento                                     AS segmento_nombre,
-            c.notas
-        FROM public.cooperativas c
-        LEFT JOIN public.datos_facturacion df ON df.id_cooperativa = c.id_cooperativa
-        LEFT JOIN public.provincia prov ON prov.id = COALESCE(c.provincia_id, df.provincia_id)
-        LEFT JOIN public.canton    can  ON can.id = COALESCE(c.canton_id, df.canton_id)
-        LEFT JOIN public.segmentos seg ON seg.id_segmento = c.id_segmento
-        WHERE c.id_cooperativa = :id
-        LIMIT 1
-        ';
-
+    public function create(array $d): int {
+        $this->db->beginTransaction();
         try {
-            $row = $this->db->fetch($sql, array(':id' => array($id, PDO::PARAM_INT)));
+            $sql = "INSERT INTO ".self::TBL."
+                    (nombre, ruc, telefono_fijo_1, telefono_movil, email,
+                     provincia_id, canton_id, tipo_entidad, id_segmento, notas)
+                    VALUES
+                    (:nombre, :ruc, :tfijo, :tmovil, :email,
+                     :prov, :canton, :tipo, :seg, :notas)
+                    RETURNING ".self::PK." AS id";
+            $st = $this->db->prepare($sql);
+            $st->execute([
+                ':nombre'=>$d['nombre'],
+                ':ruc'=>$d['ruc'],
+                ':tfijo'=>$d['telefono_fijo_1'],
+                ':tmovil'=>$d['telefono_movil'],
+                ':email'=>$d['email'],
+                ':prov'=>$d['provincia_id'],
+                ':canton'=>$d['canton_id'],
+                ':tipo'=>$d['tipo_entidad'],
+                ':seg'=>$d['id_segmento'],
+                ':notas'=>$d['notas'],
+            ]);
+            $id = (int)$st->fetchColumn();
+
+            $this->replaceServicios($id, $d['servicios']);
+            $this->db->commit();
+            return $id;
         } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener el detalle de la entidad.', 0, $e);
-        }
-
-        return $row ?: null;
-    }
-
-    public function serviciosActivos(int $id): array
-    {
-        $sql = '
-        SELECT s.id_servicio, s.nombre_servicio
-        FROM public.cooperativa_servicio cs
-        JOIN public.servicios s ON s.id_servicio = cs.id_servicio
-        WHERE cs.id_cooperativa = :id AND cs.activo = true
-        ORDER BY s.nombre_servicio
-        ';
-
-        try {
-            return $this->db->fetchAll($sql, array(':id' => array($id, PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener los servicios activos.', 0, $e);
+            if ($this->db->inTransaction()) $this->db->rollBack();
+            throw $e;
         }
     }
 
-    /** Crear y devolver el id nuevo */
-    public function create(array $d): int
-    {
-        $sql = '
-            INSERT INTO ' . self::T_COOP . '
-                (
-                    ' . self::COL_NOMBRE . ',
-                    ' . self::COL_RUC . ',
-                    ' . self::COL_MAIL . ',
-                    ' . self::COL_PROV . ',
-                    ' . self::COL_CANTON . ',
-                    ' . self::COL_SEGMENTO . ',
-                    ' . self::COL_NOTAS . ',
-                    ' . self::COL_TIPO . '
-                )
-            VALUES
-                (
-                    :nombre,
-                    :ruc,
-                    :email,
-                    :provincia_id,
-                    :canton_id,
-                    :segmento_id,
-                    :notas,
-                    :tipo_entidad
-                )
-            RETURNING ' . self::COL_ID . ' AS id
-        ';
-
-        $params = array(
-            ':nombre'       => array($d['nombre'], PDO::PARAM_STR),
-            ':ruc'          => $this->nullableStringParam($d['ruc'] ?? $d['nit'] ?? ''),
-            ':email'        => $this->nullableStringParam($d['email'] ?? ''),
-            ':provincia_id' => $this->nullableIntParam($d['provincia_id'] ?? null),
-            ':canton_id'    => $this->nullableIntParam($d['canton_id'] ?? null),
-            ':segmento_id'  => $this->nullableIntParam($d['id_segmento'] ?? $d['segmento_id'] ?? null),
-            ':notas'        => $this->nullableStringParam($d['notas'] ?? ''),
-            ':tipo_entidad' => array(
-                isset($d['tipo_entidad']) && $d['tipo_entidad'] !== '' ? (string)$d['tipo_entidad'] : 'cooperativa',
-                PDO::PARAM_STR
-            ),
-        );
-
+    public function update(int $id, array $d): void {
+        $this->db->beginTransaction();
         try {
-            $rows = $this->db->execute($sql, $params);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al crear la entidad.', 0, $e);
-        }
+            $sql = "UPDATE ".self::TBL." SET
+                      nombre=:nombre, ruc=:ruc,
+                      telefono_fijo_1=:tfijo, telefono_movil=:tmovil,
+                      email=:email, provincia_id=:prov, canton_id=:canton,
+                      tipo_entidad=:tipo, id_segmento=:seg, notas=:notas
+                    WHERE ".self::PK." = :id";
+            $st = $this->db->prepare($sql);
+            $st->execute([
+                ':nombre'=>$d['nombre'], ':ruc'=>$d['ruc'],
+                ':tfijo'=>$d['telefono_fijo_1'], ':tmovil'=>$d['telefono_movil'],
+                ':email'=>$d['email'], ':prov'=>$d['provincia_id'], ':canton'=>$d['canton_id'],
+                ':tipo'=>$d['tipo_entidad'], ':seg'=>$d['id_segmento'], ':notas'=>$d['notas'],
+                ':id'=>$id,
+            ]);
 
-        $row = is_array($rows) && isset($rows[0]) ? $rows[0] : null;
-        if (!$row || !isset($row['id'])) {
-            throw new RuntimeException('INSERT cooperativas no devolvió id');
-        }
-
-        return (int)$row['id'];
-    }
-
-    /** Actualizar */
-    public function update(int $id, array $d): void
-    {
-        $sql = '
-            UPDATE ' . self::T_COOP . ' SET
-                ' . self::COL_NOMBRE . '   = :nombre,
-                ' . self::COL_RUC . '      = :ruc,
-                ' . self::COL_TFIJ . '    = :tfijo,
-                ' . self::COL_TMOV . '     = :tmov,
-                ' . self::COL_MAIL . '    = :email,
-                ' . self::COL_PROV . '     = :prov,
-                ' . self::COL_CANTON . '   = :canton,
-                ' . self::COL_TIPO . '     = :tipo,
-                ' . self::COL_SEGMENTO . ' = :segmento,
-                ' . self::COL_NOTAS . '    = :notas,
-                ' . self::COL_ACTV . '   = :activa
-            WHERE ' . self::COL_ID . ' = :id
-        ';
-
-        $params = $this->buildEntidadParams($d);
-        $params[':id'] = array($id, PDO::PARAM_INT);
-
-        try {
-            $this->db->execute($sql, $params);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al actualizar la entidad.', 0, $e);
-        }
-    }
-
-    /** Eliminar */
-    public function delete(int $id): void
-    {
-        $sql = 'DELETE FROM ' . self::T_COOP . ' WHERE ' . self::COL_ID . ' = :id';
-        try {
-            $this->db->execute($sql, array(':id' => array($id, PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al eliminar la entidad.', 0, $e);
-        }
-    }
-
-    /** Catálogo de servicios activos */
-    public function servicios(): array
-    {
-        $sql = 'SELECT ' . self::COL_ID_SERV . ' AS id_servicio, ' . self::COL_NOM_SERV . ' AS nombre_servicio'
-                . ' FROM ' . self::T_SERV
-                . ' WHERE ' . self::COL_SERV_ACTIVO . ' = true'
-                . ' ORDER BY ' . self::COL_ID_SERV;
-        try {
-            return $this->db->fetchAll($sql);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener los servicios.', 0, $e);
-        }
-    }
-
-    /** Catálogo de segmentos (1..5) */
-    public function segmentos(): array
-    {
-        $sql = 'SELECT ' . self::COL_ID_SEG . ' AS id_segmento, ' . self::COL_NOM_SEG . ' AS nombre_segmento'
-                . ' FROM ' . self::T_SEG
-                . ' ORDER BY ' . self::COL_ID_SEG;
-        try {
-            return $this->db->fetchAll($sql);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener los segmentos.', 0, $e);
-        }
-    }
-
-    /** IDs de servicios asignados a una entidad */
-    public function serviciosDeEntidad(int $id): array
-    {
-        $sql = 'SELECT ' . self::PIV_SERV . ' AS id_servicio FROM ' . self::T_PIVOT . ' WHERE ' . self::PIV_COOP . ' = :id';
-        try {
-            $rows = $this->db->fetchAll($sql, array(':id' => array($id, PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener los servicios de la entidad.', 0, $e);
-        }
-
-        $ids = array();
-        foreach ($rows as $row) {
-            if (isset($row['id_servicio'])) {
-                $ids[] = (int)$row['id_servicio'];
-            }
-        }
-        return $ids;
-    }
-
-    /** Reemplazar relación servicios (Matrix=1 exclusivo) */
-    public function replaceServicios(int $id, array $ids): void
-    {
-        $ids = array_values(array_unique(array_map('intval', $ids)));
-
-        if (in_array(1, $ids, true)) {
-            $ids = array(1);
-        }
-
-        $this->db->begin();
-        try {
-            $this->db->execute('DELETE FROM ' . self::T_PIVOT . ' WHERE ' . self::PIV_COOP . ' = :id', array(
-                ':id' => array($id, PDO::PARAM_INT),
-            ));
-
-            if (!empty($ids)) {
-                $sql = '
-                    INSERT INTO ' . self::T_PIVOT . ' (' . self::PIV_COOP . ', ' . self::PIV_SERV . ', ' . self::PIV_ACTIVO . ')
-                    VALUES (:c, :s, true)
-                ';
-                foreach ($ids as $sid) {
-                    $this->db->execute($sql, array(
-                        ':c' => array($id, PDO::PARAM_INT),
-                        ':s' => array($sid, PDO::PARAM_INT),
-                    ));
-                }
-            }
-
+            $this->replaceServicios($id, $d['servicios']);
             $this->db->commit();
         } catch (\Throwable $e) {
-            $this->db->rollBack();
-            throw new RuntimeException('Error al actualizar los servicios de la entidad.', 0, $e);
+            if ($this->db->inTransaction()) $this->db->rollBack();
+            throw $e;
         }
     }
 
-    /**
-     * @param array<int,array<string,mixed>> $rows
-     * @return array<int,array<string,mixed>>
-     */
-    private function hydrateListado(array $rows): array
-    {
-        $hydrated = array();
+    /** Borra e inserta pivot cooperativa_servicio en la misma transacción */
+    public function replaceServicios(int $id, array $ids): void {
+        // aquí asumimos que ya estamos en tx desde create/update
+        $this->db->prepare("DELETE FROM public.cooperativa_servicio WHERE id_cooperativa=:id")
+                 ->execute([':id'=>$id]);
+        if (!$ids) return;
 
-        foreach ($rows as $row) {
-            $id = isset($row['id']) ? (int)$row['id'] : 0;
-
-            $telefonos = $this->decodeJsonList($row['telefonos_json'] ?? null);
-            $emails    = $this->decodeJsonList($row['emails_json'] ?? null);
-            $servicios = $this->decodeJsonList($row['servicios_json'] ?? null);
-
-            $hydrated[] = array(
-                'id'               => $id,
-                'nombre'           => isset($row['nombre']) ? (string)$row['nombre'] : '',
-                'ruc'              => isset($row['ruc']) ? (string)$row['ruc'] : null,
-                'segmento_nombre'  => isset($row['segmento_nombre']) ? (string)$row['segmento_nombre'] : null,
-                'provincia_nombre' => isset($row['provincia_nombre']) ? (string)$row['provincia_nombre'] : null,
-                'canton_nombre'    => isset($row['canton_nombre']) ? (string)$row['canton_nombre'] : null,
-                'telefonos'        => $telefonos,
-                'emails'           => $emails,
-                'servicios'        => $servicios,
-                'servicios_count'  => isset($row['servicios_count']) ? (int)$row['servicios_count'] : 0,
-                'tipo_entidad'     => isset($row['tipo_entidad']) ? (string)$row['tipo_entidad'] : null,
-                'id_segmento'      => isset($row['id_segmento']) ? (int)$row['id_segmento'] : null,
-                'provincia_id'     => isset($row['provincia_id']) && $row['provincia_id'] !== null ? (int)$row['provincia_id'] : null,
-                'canton_id'        => isset($row['canton_id']) && $row['canton_id'] !== null ? (int)$row['canton_id'] : null,
-            );
-        }
-
-        return $hydrated;
-    }
-
-    /**
-     * @param mixed $json
-     * @return array<int,string>
-     */
-    private function decodeJsonList($json): array
-    {
-        if ($json === null || $json === '') {
-            return array();
-        }
-
-        if (is_array($json)) {
-            $list = $json;
-        } else {
-            $decoded = json_decode((string)$json, true);
-            $list    = is_array($decoded) ? $decoded : array();
-        }
-
-        $clean = array();
-        foreach ($list as $value) {
-            if (!is_scalar($value)) {
-                continue;
-            }
-            $trimmed = trim((string)$value);
-            if ($trimmed === '') {
-                continue;
-            }
-            if (!in_array($trimmed, $clean, true)) {
-                $clean[] = $trimmed;
-            }
-        }
-
-        return $clean;
-    }
-    /**
-     * @param array<string,mixed> $d
-     * @return array<string,array{0:mixed,1:int}>
-     */
-    private function buildEntidadParams(array $d): array
-    {
-        $params = array(
-            ':nombre'  => array($d['nombre'], PDO::PARAM_STR),
-            ':ruc'     => $this->nullableStringParam($d['nit'] ?? ''),
-            ':tfijo'   => $this->nullableStringParam($d['telefono_fijo'] ?? ''),
-            ':tmov'    => $this->nullableStringParam($d['telefono_movil'] ?? ''),
-            ':email'   => $this->nullableStringParam($d['email'] ?? ''),
-            ':prov'    => $this->nullableIntParam($d['provincia_id'] ?? null),
-            ':canton'  => $this->nullableIntParam($d['canton_id'] ?? null),
-            ':tipo'    => array($d['tipo_entidad'], PDO::PARAM_STR),
-            ':segmento'=> $this->nullableIntParam($d['id_segmento'] ?? null),
-            ':notas'   => $this->nullableStringParam($d['notas'] ?? ''),
-            ':activa'  => array($this->resolveActiva($d), PDO::PARAM_BOOL),
+        // Exclusividad Matrix ya viene aplicada desde Controller (si incluye 1 => [1])
+        $ins = $this->db->prepare(
+            "INSERT INTO public.cooperativa_servicio (id_cooperativa, id_servicio, activo, fecha_alta)
+             VALUES (:id, :sid, TRUE, now())"
         );
-
-        return $params;
+        foreach ($ids as $sid) {
+            $ins->execute([':id'=>$id, ':sid'=>(int)$sid]);
+        }
     }
 
-    private function resolveActiva(array $d): bool
-    {
-        if (array_key_exists('activa', $d)) {
-            return (bool)$d['activa'];
+    public function delete(int $id): void {
+        $this->db->beginTransaction();
+        try {
+            $this->db->prepare("DELETE FROM public.cooperativa_servicio WHERE id_cooperativa = :id")
+                ->execute([':id' => $id]);
+            $stmt = $this->db->prepare("DELETE FROM ".self::TBL." WHERE ".self::PK." = :id");
+            $stmt->execute([':id' => $id]);
+            $this->db->commit();
+        } catch (\Throwable $e) {
+            if ($this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+            throw $e;
         }
-        $estado = isset($d['estado']) ? (string)$d['estado'] : 'activo';
-        return $estado === 'activo';
-    }
-
-    /**
-     * @param mixed $value
-     * @return array{0:mixed,1:int}
-     */
-    private function nullableStringParam($value): array
-    {
-        if ($value === null) {
-            return array(null, PDO::PARAM_NULL);
-        }
-        $value = (string)$value;
-        if ($value === '') {
-            return array(null, PDO::PARAM_NULL);
-        }
-        return array($value, PDO::PARAM_STR);
-    }
-
-    /**
-     * @param mixed $value
-     * @return array{0:mixed,1:int}
-     */
-    private function nullableIntParam($value): array
-    {
-        if ($value === null || $value === '') {
-            return array(null, PDO::PARAM_NULL);
-        }
-        return array((int)$value, PDO::PARAM_INT);
     }
 }

--- a/app/Repositories/Shared/UbicacionesRepository.php
+++ b/app/Repositories/Shared/UbicacionesRepository.php
@@ -3,30 +3,33 @@ declare(strict_types=1);
 
 namespace App\Repositories\Shared;
 
-use App\Repositories\BaseRepository;
-use RuntimeException;
+use PDO;
 
-final class UbicacionesRepository extends BaseRepository
+final class UbicacionesRepository
 {
-    /** @return array<int, array{id:int, nombre:string}> */
-    public function provincias(): array
+    private PDO $db;
+
+    public function __construct(PDO $db)
     {
-        $sql = 'SELECT id, nombre FROM public.provincia ORDER BY nombre';
-        try {
-            return $this->db->fetchAll($sql);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener provincias.', 0, $e);
-        }
+        $this->db = $db;
     }
 
     /** @return array<int, array{id:int, nombre:string}> */
-    public function cantonesPorProvincia(int $provinciaId): array
+    public function provincias(): array
     {
-        $sql = 'SELECT id, nombre FROM public.canton WHERE provincia_id = :p ORDER BY nombre';
-        try {
-            return $this->db->fetchAll($sql, array(':p' => array($provinciaId, \PDO::PARAM_INT)));
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener cantones.', 0, $e);
-        }
+        $sql = "SELECT id_provincia AS id, nombre FROM public.provincias ORDER BY nombre";
+        $stmt = $this->db->query($sql);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /** @return array<int, array{id:int, nombre:string}> */
+    public function cantones(int $provinciaId): array
+    {
+        $stmt = $this->db->prepare(
+            "SELECT id_canton AS id, nombre FROM public.cantones
+             WHERE provincia_id = :pid ORDER BY nombre"
+        );
+        $stmt->execute([':pid' => $provinciaId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 }

--- a/app/Services/Comercial/ActualizarEntidadService.php
+++ b/app/Services/Comercial/ActualizarEntidadService.php
@@ -1,21 +1,31 @@
 <?php
+declare(strict_types=1);
+
 namespace App\Services\Comercial;
 
 use App\Repositories\Comercial\EntidadRepository;
 use App\Services\Shared\ValidationService;
+use Config\Cnxn;
 
 final class ActualizarEntidadService
 {
-    private $repo;
-    private $val;
-    public function __construct() { $this->repo = new EntidadRepository(); $this->val = new ValidationService(); }
+    private EntidadRepository $repo;
+    private ValidationService $val;
+
+    public function __construct(?EntidadRepository $repo = null, ?ValidationService $val = null)
+    {
+        $this->repo = $repo ?? new EntidadRepository(Cnxn::pdo());
+        $this->val  = $val ?? new ValidationService();
+    }
 
     /** @return array{ok:bool, errors?:array, data?:array} */
     public function actualizar(int $id, array $input): array
     {
         $v = $this->val->validarEntidad($input);
-        if (!$v['ok']) return ['ok'=>false, 'errors'=>$v['errors'], 'data'=>$v['data']];
-        $ok = $this->repo->update($id, $v['data']);
-        return ['ok'=>$ok];
+        if (!$v['ok']) {
+            return ['ok' => false, 'errors' => $v['errors'], 'data' => $v['data']];
+        }
+        $this->repo->update($id, $v['data']);
+        return ['ok' => true];
     }
 }

--- a/app/Services/Comercial/BuscarEntidadesService.php
+++ b/app/Services/Comercial/BuscarEntidadesService.php
@@ -1,17 +1,20 @@
 <?php
+declare(strict_types=1);
+
 namespace App\Services\Comercial;
 
-use App\Repositories\Comercial\EntidadRepository;
+use App\Repositories\Comercial\EntidadQueryRepository;
 use App\Services\Shared\ValidationService;
+use Config\Cnxn;
 
 final class BuscarEntidadesService
 {
-    private EntidadRepository $repository;
+    private EntidadQueryRepository $repository;
     private ValidationService $validator;
 
-    public function __construct(?EntidadRepository $repository = null, ?ValidationService $validator = null)
+    public function __construct(?EntidadQueryRepository $repository = null, ?ValidationService $validator = null)
     {
-        $this->repository = $repository ?? new EntidadRepository();
+        $this->repository = $repository ?? new EntidadQueryRepository(Cnxn::pdo());
         $this->validator  = $validator ?? new ValidationService();
     }
 
@@ -85,6 +88,13 @@ final class BuscarEntidadesService
      */
     private function sanitizeList($values): array
     {
+        if (is_string($values)) {
+            $jsonDecoded = json_decode($values, true);
+            if (is_array($jsonDecoded)) {
+                $values = $jsonDecoded;
+            }
+        }
+
         if (!is_array($values)) {
             if ($values === null || $values === '') {
                 return [];

--- a/app/Services/Comercial/CrearEntidadService.php
+++ b/app/Services/Comercial/CrearEntidadService.php
@@ -1,21 +1,31 @@
 <?php
+declare(strict_types=1);
+
 namespace App\Services\Comercial;
 
 use App\Repositories\Comercial\EntidadRepository;
 use App\Services\Shared\ValidationService;
+use Config\Cnxn;
 
 final class CrearEntidadService
 {
-    private $repo;
-    private $val;
-    public function __construct() { $this->repo = new EntidadRepository(); $this->val = new ValidationService(); }
+    private EntidadRepository $repo;
+    private ValidationService $val;
+
+    public function __construct(?EntidadRepository $repo = null, ?ValidationService $val = null)
+    {
+        $this->repo = $repo ?? new EntidadRepository(Cnxn::pdo());
+        $this->val  = $val ?? new ValidationService();
+    }
 
     /** @return array{ok:bool, id?:int, errors?:array, data?:array} */
     public function crear(array $input): array
     {
         $v = $this->val->validarEntidad($input);
-        if (!$v['ok']) return ['ok'=>false, 'errors'=>$v['errors'], 'data'=>$v['data']];
+        if (!$v['ok']) {
+            return ['ok' => false, 'errors' => $v['errors'], 'data' => $v['data']];
+        }
         $id = $this->repo->create($v['data']);
-        return ['ok'=>true, 'id'=>$id];
+        return ['ok' => true, 'id' => $id];
     }
 }

--- a/app/Services/Comercial/EliminarEntidadService.php
+++ b/app/Services/Comercial/EliminarEntidadService.php
@@ -1,11 +1,23 @@
 <?php
+declare(strict_types=1);
+
 namespace App\Services\Comercial;
 
 use App\Repositories\Comercial\EntidadRepository;
+use Config\Cnxn;
 
 final class EliminarEntidadService
 {
-    private $repo;
-    public function __construct() { $this->repo = new EntidadRepository(); }
-    public function eliminar(int $id): bool { return $this->repo->delete($id); }
+    private EntidadRepository $repo;
+
+    public function __construct(?EntidadRepository $repo = null)
+    {
+        $this->repo = $repo ?? new EntidadRepository(Cnxn::pdo());
+    }
+
+    public function eliminar(int $id): bool
+    {
+        $this->repo->delete($id);
+        return true;
+    }
 }

--- a/app/Services/Shared/UbicacionesService.php
+++ b/app/Services/Shared/UbicacionesService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Services\Shared;
 
 use App\Repositories\Shared\UbicacionesRepository;
+use Config\Cnxn;
 
 /**
  * Provincias y Cantones (Ecuador).
@@ -11,12 +12,11 @@ use App\Repositories\Shared\UbicacionesRepository;
  */
 final class UbicacionesService
 {
-    /** @var UbicacionesRepository */
-    private $repo;
+    private UbicacionesRepository $repo;
 
     public function __construct(?UbicacionesRepository $repo = null)
     {
-        $this->repo = $repo ?: new UbicacionesRepository();
+        $this->repo = $repo ?? new UbicacionesRepository(Cnxn::pdo());
     }
 
     /** @return array<int, array{id:int, nombre:string}> */
@@ -28,7 +28,9 @@ final class UbicacionesService
     /** @return array<int, array{id:int, nombre:string}> */
     public function cantones(int $provinciaId): array
     {
-        if ($provinciaId <= 0) return [];
-        return $this->repo->cantonesPorProvincia($provinciaId);
+        if ($provinciaId <= 0) {
+            return [];
+        }
+        return $this->repo->cantones($provinciaId);
     }
 }

--- a/app/Services/Shared/ValidationService.php
+++ b/app/Services/Shared/ValidationService.php
@@ -34,7 +34,7 @@ final class ValidationService
         $data = [
             'nombre'          => trim((string)($in['nombre'] ?? '')),
             'ruc'             => $digits($in['nit'] ?? $in['ruc'] ?? ''), // admite 'nit' o 'ruc'
-            'telefono_fijo'   => $digits($in['telefono_fijo'] ?? $in['tfijo'] ?? ''),
+            'telefono_fijo'   => $digits($in['telefono_fijo'] ?? $in['telefono_fijo_1'] ?? $in['tfijo'] ?? ''),
             'telefono_movil'  => $digits($in['telefono_movil'] ?? $in['tmov'] ?? ''),
             'email'           => trim((string)($in['email'] ?? '')),
             'provincia_id'    => $intOrNull($in['provincia_id'] ?? null),
@@ -87,6 +87,14 @@ final class ValidationService
             // por defecto dejamos "cooperativa"
             $data['tipo_entidad'] = 'cooperativa';
         }
+
+        $data['ruc'] = $data['ruc'] === '' ? null : $data['ruc'];
+        $data['telefono_fijo_1'] = $data['telefono_fijo'] === '' ? null : $data['telefono_fijo'];
+        unset($data['telefono_fijo']);
+        $data['telefono'] = null;
+        $data['telefono_movil'] = $data['telefono_movil'] === '' ? null : $data['telefono_movil'];
+        $data['email'] = $data['email'] === '' ? null : $data['email'];
+        $data['notas'] = $data['notas'] === '' ? null : $data['notas'];
 
         return ['ok' => empty($e), 'errors' => $e, 'data' => $data];
     }

--- a/app/Views/comercial/entidades/index.php
+++ b/app/Views/comercial/entidades/index.php
@@ -264,7 +264,7 @@ function buildPageUrl(int $pageNumber, array $filters, int $perPage): string
                       aria-label="Ver detalles de <?= h($cardTitle) ?>">
                 Ver
               </button>
-              <a class="btn btn-primary" href="/comercial/entidades/editar?id=<?= h((string)$entityId) ?>">Editar</a>
+              <a class="btn btn-primary" href="/comercial/entidades/<?= h((string)$entityId) ?>/edit">Editar</a>
               <form method="post" action="/comercial/entidades/eliminar" class="ent-card-delete" aria-label="Eliminar <?= h($cardTitle) ?>">
                 <input type="hidden" name="_csrf" value="<?= h($csrf) ?>">
                 <input type="hidden" name="id" value="<?= h((string)$entityId) ?>">

--- a/app/Views/comercial/entidades/index_cards.php
+++ b/app/Views/comercial/entidades/index_cards.php
@@ -225,7 +225,7 @@ function buildPageUrl(int $pageNumber, array $filters, int $perPage): string
                       aria-label="Ver detalles de <?= h($cardTitle) ?>">
                 Ver
               </button>
-              <a class="btn btn-primary" href="/comercial/entidades/editar?id=<?= h((string)$entityId) ?>">Editar</a>
+              <a class="btn btn-primary" href="/comercial/entidades/<?= h((string)$entityId) ?>/edit">Editar</a>
               <form method="post" action="/comercial/entidades/eliminar" class="ent-card-delete" aria-label="Eliminar <?= h($cardTitle) ?>">
                 <input type="hidden" name="_csrf" value="<?= h($csrf) ?>">
                 <input type="hidden" name="id" value="<?= h((string)$entityId) ?>">

--- a/config/routes.php
+++ b/config/routes.php
@@ -6,7 +6,7 @@ use App\Controllers\Contabilidad\DashboardController as ContabDashboard;
 use App\Controllers\Sistemas\DashboardController as SistemasDashboard;
 use App\Controllers\Cumplimiento\DashboardController as CumplimientoDashboard;
 use App\Controllers\Administrador\DashboardController as AdminDashboard;
-use App\Controllers\Comercial\EntidadesController;
+use App\Controllers\Comercial\EntidadesController as Ctrl;
 use App\Controllers\Comercial\AgendaController;
 
 // ---------- Auth ----------
@@ -30,6 +30,7 @@ $router->get('/contabilidad/dashboard',  [ContabDashboard::class,      'index'],
 $router->get('/sistemas/dashboard',      [SistemasDashboard::class,    'index'], ['middleware'=>['auth','role:sistemas,administrador']]);
 $router->get('/cumplimiento/dashboard',  [CumplimientoDashboard::class,'index'], ['middleware'=>['auth','role:cumplimiento,administrador']]);
 $router->get('/administrador/dashboard', [AdminDashboard::class,       'index'], ['middleware'=>['auth','role:administrador']]);
+
 $router->get(
     '/comercial/entidades/cards',
     function () {
@@ -38,22 +39,22 @@ $router->get(
     },
     ['middleware'=>['auth','role:comercial']]
 );
-$router->get('/comercial/entidades/ver', [EntidadesController::class, 'show'], ['middleware'=>['auth','role:comercial,administrador']]);
-$router->get('/comercial/entidades/{id}/show', [EntidadesController::class, 'showJson'], ['middleware'=>['auth','role:comercial']]);
+$router->get('/comercial/entidades/ver', [Ctrl::class, 'show'], ['middleware'=>['auth','role:comercial']]);
+$router->get('/comercial/entidades/{id}/show', [Ctrl::class, 'showJson'], ['middleware'=>['auth','role:comercial']]);
 
 // ---------- Comercial → Entidades (CRUD, auth + role) ----------
 $router->get(
     '/comercial/entidades',
-    [EntidadesController::class, 'index'],
+    [Ctrl::class, 'index'],
     ['middleware'=>['auth','role:comercial']]
 );
-$router->get('/comercial/entidades/crear',     [EntidadesController::class, 'createForm'], ['middleware'=>['auth','role:comercial,administrador']]);
-$router->post('/comercial/entidades',          [EntidadesController::class, 'create'],     ['middleware'=>['auth','role:comercial,administrador']]);
-$router->get('/comercial/entidades/editar',    [EntidadesController::class, 'editForm'],   ['middleware'=>['auth','role:comercial,administrador']]);
-$router->post('/comercial/entidades/{id}',     [EntidadesController::class, 'update'],     ['middleware'=>['auth','role:comercial,administrador']]);
-$router->post('/comercial/entidades/eliminar', [EntidadesController::class, 'delete'],     ['middleware'=>['auth','role:comercial,administrador']]);
+$router->get('/comercial/entidades/crear',     [Ctrl::class, 'createForm'], ['middleware'=>['auth','role:comercial']]);
+$router->post('/comercial/entidades',          [Ctrl::class, 'create'],    ['middleware'=>['auth','role:comercial']]);
+$router->get('/comercial/entidades/{id}/edit', [Ctrl::class, 'editForm'],  ['middleware'=>['auth','role:comercial']]);
+$router->post('/comercial/entidades/{id}',     [Ctrl::class, 'update'],    ['middleware'=>['auth','role:comercial']]);
+$router->post('/comercial/entidades/eliminar', [Ctrl::class, 'delete'],    ['middleware'=>['auth','role:comercial']]);
 
-// 
+//
 
 $router->get('/comercial/agenda',                   [AgendaController::class, 'index'],        ['middleware'=>['auth','role:comercial']]);
 $router->post('/comercial/agenda',                  [AgendaController::class, 'create'],       ['middleware'=>['auth','role:comercial']]);
@@ -64,3 +65,4 @@ $router->post('/comercial/agenda/{id}/eliminar',    [AgendaController::class, 'd
 
 // AJAX: cantones por provincia (auth)
 $router->get('/shared/cantones', [UbicacionesController::class, 'cantones'], ['middleware'=>['auth']]);
+


### PR DESCRIPTION
## Summary
- replace the comercial EntidadRepository with a PDO-injected implementation that wraps writes in transactions and refreshes pivot rows on id_cooperativa
- add an EntidadQueryRepository and update services/controllers (including agenda) to rely on it for listings, details, and catalog data while normalizing request payloads
- align forms, validation, and routes with the new DTO keys and REST endpoints, keeping CSRF handling consistent

## Testing
- `php -l app/Repositories/Comercial/EntidadRepository.php`
- `php -l app/Controllers/Comercial/EntidadesController.php`
- `php -l config/routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68d993b655b08326915e4787ce8ea001