### PR TITLE
Ensure entidad forms keep database ID and drop CSRF tokens

### DIFF
--- a/app/Controllers/Comercial/EntidadesController.php
+++ b/app/Controllers/Comercial/EntidadesController.php
@@ -10,8 +10,6 @@ use App\Services\Shared\UbicacionesService;
 use App\Support\Logger;
 use function \view;
 use function \redirect;
-use function \csrf_token;
-use function \csrf_verify;
 
 final class EntidadesController
 {
@@ -54,7 +52,6 @@ final class EntidadesController
             'page'    => $result['page'],
             'perPage' => $result['perPage'],
             'q'       => $q,
-            'csrf'    => csrf_token(),
             'filters' => $filters,
             'toastMessage' => $toastMessage,
         ]);
@@ -103,7 +100,6 @@ final class EntidadesController
         view('comercial/entidades/create', [
             'title'      => 'Nueva Entidad',
             'crumbs'     => $crumbs,
-            'csrf'       => csrf_token(),
             'provincias' => $provincias, // <<<<<
             'action'     => '/comercial/entidades',
             'segmentos'  => $repo->segmentos(),
@@ -113,8 +109,6 @@ final class EntidadesController
 
     public function create(): void
     {
-        if (!csrf_verify($_POST['_csrf'] ?? '')) { http_response_code(400); echo 'CSRF inválido'; return; }
-
         $repo = $this->entidades;
         $res  = $this->validator->validarEntidad($_POST);
 
@@ -124,7 +118,6 @@ final class EntidadesController
             view('comercial/entidades/create', [
                 'title'=>'Nueva Cooperativa',
                 'crumbs'=>$crumbs,
-                'csrf'=>csrf_token(),
                 'provincias'=>$this->ubicaciones->provincias(),
                 'cantones'=>$this->ubicaciones->cantones((int)($res['data']['provincia_id'] ?? 0)),
                 'segmentos'=>$repo->segmentos(),
@@ -138,14 +131,14 @@ final class EntidadesController
         }
 
         try {
-            $repo->create($res['data']);
+            $newId = $repo->create($res['data']);
         } catch (\Throwable $e) {
             Logger::error($e, 'EntidadesController::create');
             http_response_code(500);
             echo 'No se pudo guardar la entidad';
             return;
         }
-        redirect('/comercial/entidades?created=1');
+        redirect('/comercial/entidades/editar?id=' . $newId . '&created=1');
     }
 
     public function editForm(): void
@@ -156,6 +149,10 @@ final class EntidadesController
         $repo = $this->entidades;
         $row  = $repo->findById($id);
         if (!$row) { redirect('/comercial/entidades'); }
+
+        $row['id'] = (int)($row['id'] ?? $row['id_cooperativa'] ?? $id);
+        $row['id_entidad'] = (int)($row['id_entidad'] ?? $row['id'] ?? $id);
+        $row['id_cooperativa'] = (int)($row['id_cooperativa'] ?? $row['id'] ?? $id);
 
         $crumbs = Breadcrumbs::make([
             ['href'=>'/comercial', 'label'=>'Comercial'],
@@ -170,7 +167,6 @@ final class EntidadesController
             'title'      => 'Editar Entidad',
             'crumbs'     => $crumbs,
             'item'       => $row,
-            'csrf'       => csrf_token(),
             'provincias' => $provincias, // <<<<<
             'action'     => '/comercial/entidades/' . $id,
             'cantones'   => $cantones,
@@ -181,7 +177,6 @@ final class EntidadesController
 
     public function update($id): void
     {
-        if (!csrf_verify($_POST['_csrf'] ?? '')) { http_response_code(400); echo 'CSRF inválido'; return; }
         $id = (int)$id;
         if ($id < 1) {
             $id = (int)($_POST['id'] ?? 0);
@@ -194,12 +189,14 @@ final class EntidadesController
         if (!$res['ok']) {
             http_response_code(400);
             $row = array_merge((array)$repo->findById($id), $res['data']);
+            $row['id'] = $id;
+            $row['id_entidad'] = $id;
+            $row['id_cooperativa'] = $id;
             $crumbs = [['href'=>'/comercial','label'=>'Comercial'],['href'=>'/comercial/entidades','label'=>'Entidades'],['label'=>'Editar']];
             view('comercial/entidades/edit', [
                 'title'=>'Editar Cooperativa',
                 'crumbs'=>$crumbs,
                 'item'=>$row,
-                'csrf'=>csrf_token(),
                 'provincias'=>$this->ubicaciones->provincias(),
                 'cantones'=>$this->ubicaciones->cantones((int)($row['provincia_id'] ?? $res['data']['provincia_id'] ?? 0)),
                 'segmentos'=>$repo->segmentos(),
@@ -226,7 +223,6 @@ final class EntidadesController
 
     public function delete(): void
     {
-        if (!csrf_verify($_POST['_csrf'] ?? '')) { http_response_code(400); echo 'CSRF inválido'; return; }
         $id = (int)($_POST['id'] ?? 0);
         if ($id > 0) { $this->entidades->delete($id); }
         redirect('/comercial/entidades');

--- a/app/Repositories/Comercial/EntidadRepository.php
+++ b/app/Repositories/Comercial/EntidadRepository.php
@@ -192,6 +192,8 @@ final class EntidadRepository extends BaseRepository
         $sql = '
             SELECT
                 ' . self::COL_ID . '    AS id_cooperativa,
+                ' . self::COL_ID . '    AS id,
+                ' . self::COL_ID . '    AS id_entidad,
                 ' . self::COL_NOMBRE . '     AS nombre,
                 ' . self::COL_RUC . '        AS nit,
                 ' . self::COL_TFIJ . '      AS telefono_fijo_1,

--- a/app/Views/comercial/entidades/create.php
+++ b/app/Views/comercial/entidades/create.php
@@ -9,7 +9,6 @@ $action = isset($action) ? (string)$action : '/comercial/entidades';
 <section class="card ent-container">
   <h1 class="ent-title">Nueva Cooperativa</h1>
   <form method="post" action="<?= htmlspecialchars($action, ENT_QUOTES, 'UTF-8') ?>" class="form ent-form">
-    <input type="hidden" name="_csrf" value="<?= htmlspecialchars($csrf ?? '', ENT_QUOTES, 'UTF-8') ?>">
     <?php include __DIR__ . '/_form.php'; ?>
     <div class="form-actions ent-actions">
       <button class="btn btn-primary" type="submit">Guardar</button>

--- a/app/Views/comercial/entidades/edit.php
+++ b/app/Views/comercial/entidades/edit.php
@@ -10,7 +10,6 @@ $action    = isset($action) ? (string)$action : '/comercial/entidades/' . $entit
 <section class="card ent-container">
   <h1 class="ent-title">Editar Cooperativa</h1>
   <form method="post" action="<?= htmlspecialchars($action, ENT_QUOTES, 'UTF-8') ?>" class="form ent-form">
-    <input type="hidden" name="_csrf" value="<?= htmlspecialchars($csrf ?? '', ENT_QUOTES, 'UTF-8') ?>">
     <input type="hidden" name="id" value="<?= $entityId ?>">
     <?php include __DIR__ . '/_form.php'; ?>
     <div class="form-actions ent-actions">

--- a/app/Views/comercial/entidades/index.php
+++ b/app/Views/comercial/entidades/index.php
@@ -5,7 +5,6 @@ use App\Services\Shared\Pagination;
 /** @var int   $page   Página actual */
 /** @var int   $perPage Elementos por página */
 /** @var string $q     Búsqueda actual */
-/** @var string $csrf  Token CSRF */
 /** @var array $filters Filtros activos */
 /** @var string|null $toastMessage Mensaje de éxito */
 
@@ -266,7 +265,6 @@ function buildPageUrl(int $pageNumber, array $filters, int $perPage): string
               </button>
               <a class="btn btn-primary" href="/comercial/entidades/editar?id=<?= h((string)$entityId) ?>">Editar</a>
               <form method="post" action="/comercial/entidades/eliminar" class="ent-card-delete" aria-label="Eliminar <?= h($cardTitle) ?>">
-                <input type="hidden" name="_csrf" value="<?= h($csrf) ?>">
                 <input type="hidden" name="id" value="<?= h((string)$entityId) ?>">
                 <button type="submit" class="btn btn-danger" onclick="return confirm('¿Deseas eliminar esta entidad?');">Eliminar</button>
               </form>

--- a/app/Views/comercial/entidades/index_cards.php
+++ b/app/Views/comercial/entidades/index_cards.php
@@ -5,7 +5,6 @@ use App\Services\Shared\Pagination;
 /** @var int   $page   Página actual */
 /** @var int   $perPage Elementos por página */
 /** @var string $q     Búsqueda actual */
-/** @var string $csrf  Token CSRF */
 /** @var array $filters Filtros activos */
 
 function h($value): string
@@ -227,7 +226,6 @@ function buildPageUrl(int $pageNumber, array $filters, int $perPage): string
               </button>
               <a class="btn btn-primary" href="/comercial/entidades/editar?id=<?= h((string)$entityId) ?>">Editar</a>
               <form method="post" action="/comercial/entidades/eliminar" class="ent-card-delete" aria-label="Eliminar <?= h($cardTitle) ?>">
-                <input type="hidden" name="_csrf" value="<?= h($csrf) ?>">
                 <input type="hidden" name="id" value="<?= h((string)$entityId) ?>">
                 <button type="submit" class="btn btn-danger" onclick="return confirm('¿Deseas eliminar esta entidad?');">Eliminar</button>
               </form>


### PR DESCRIPTION
## Summary
- ensure the entidad repository exposes the database identifier so edit forms always receive the correct ID
- redirect new entity creations to the edit route using the returned ID and strip CSRF dependencies from the controller
- remove unused CSRF hidden inputs from entidad views while keeping delete actions intact

## Testing
- php -l app/Controllers/Comercial/EntidadesController.php
- php -l app/Repositories/Comercial/EntidadRepository.php
- php -l app/Views/comercial/entidades/index.php
- php -l app/Views/comercial/entidades/index_cards.php
- php -l app/Views/comercial/entidades/create.php
- php -l app/Views/comercial/entidades/edit.php

------
https://chatgpt.com/codex/tasks/task_e_68d9ade83140832691553035610b4432