### PR TITLE
Refactor contact list view and add contact editing form

### DIFF
--- a/app/Controllers/Comercial/ContactosController.php
+++ b/app/Controllers/Comercial/ContactosController.php
@@ -75,6 +75,57 @@ final class ContactosController
     }
 
     /**
+     * Muestra el formulario para editar un contacto existente.
+     */
+    public function editForm()
+    {
+        $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+        if ($id < 1) {
+            redirect('/comercial/contactos');
+            return;
+        }
+
+        $contacto = $this->repo->find($id);
+        if ($contacto === null) {
+            redirect('/comercial/contactos');
+            return;
+        }
+
+        return view('comercial/contactos/edit', [
+            'layout'    => 'layout',
+            'title'     => 'Editar contacto',
+            'contacto'  => $contacto,
+            'entidades' => $this->listadoEntidades(),
+        ]);
+    }
+
+    /**
+     * Actualiza un contacto.
+     *
+     * @param int|string $id
+     */
+    public function update($id)
+    {
+        $id = (int)$id;
+        if ($id < 1) {
+            redirect('/comercial/contactos');
+            return;
+        }
+
+        $data = [
+            'id_cooperativa'    => (int)($_POST['id_entidad'] ?? 0),
+            'nombre'            => trim((string)($_POST['nombre'] ?? '')),
+            'titulo'            => trim((string)($_POST['titulo'] ?? '')),
+            'cargo'             => trim((string)($_POST['cargo'] ?? '')),
+            'telefono_contacto' => trim((string)($_POST['telefono'] ?? '')),
+            'email_contacto'    => trim((string)($_POST['correo'] ?? '')),
+            'nota'              => trim((string)($_POST['nota'] ?? '')),
+        ];
+        $this->repo->update($id, $data);
+        redirect('/comercial/contactos');
+    }
+
+    /**
      * Elimina un contacto identificado por su id.
      *
      * @param int|string $id Identificador del contacto a eliminar.

--- a/app/Repositories/Comercial/ContactoRepository.php
+++ b/app/Repositories/Comercial/ContactoRepository.php
@@ -123,6 +123,61 @@ final class ContactoRepository extends BaseRepository
     }
 
     /**
+     * Obtiene un contacto por su identificador.
+     *
+     * @param int $id
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        if ($id < 1) {
+            return null;
+        }
+
+        $nombreExpr = "COALESCE(c." . self::COL_NOMBRE_RAW . ", c." . self::COL_CONTACTO_ALT . ")";
+
+        $sql = '
+            SELECT
+                c.' . self::COL_ID . ' AS id,
+                c.' . self::COL_COOP . ' AS id_entidad,
+                e.' . self::COL_COOP_NOMBRE . ' AS entidad_nombre,
+                ' . $nombreExpr . ' AS nombre,
+                c.' . self::COL_TITULO . ' AS titulo,
+                c.' . self::COL_CARGO . ' AS cargo,
+                c.' . self::COL_TEL . ' AS telefono,
+                c.' . self::COL_MAIL . ' AS correo,
+                c.' . self::COL_NOTA . ' AS nota
+            FROM ' . self::T_CONTACTO . ' c
+            INNER JOIN ' . self::T_COOP . ' e
+                ON e.' . self::COL_COOP_ID . ' = c.' . self::COL_COOP . '
+            WHERE c.' . self::COL_ID . ' = :id
+            LIMIT 1
+        ';
+
+        try {
+            $row = $this->db->fetch($sql, [':id' => [$id, PDO::PARAM_INT]]);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('Error al obtener el contacto.', 0, $e);
+        }
+
+        if (!$row) {
+            return null;
+        }
+
+        return [
+            'id'             => isset($row['id']) ? (int)$row['id'] : $id,
+            'id_entidad'     => isset($row['id_entidad']) ? (int)$row['id_entidad'] : null,
+            'entidad_nombre' => (string)($row['entidad_nombre'] ?? ''),
+            'nombre'         => (string)($row['nombre'] ?? ''),
+            'titulo'         => (string)($row['titulo'] ?? ''),
+            'cargo'          => (string)($row['cargo'] ?? ''),
+            'telefono'       => (string)($row['telefono'] ?? ''),
+            'correo'         => (string)($row['correo'] ?? ''),
+            'nota'           => (string)($row['nota'] ?? ''),
+        ];
+    }
+
+    /**
      * Inserta un nuevo contacto y devuelve su ID.
      *
      * @param array<string,mixed> $d

--- a/app/Views/comercial/contactos/edit.php
+++ b/app/Views/comercial/contactos/edit.php
@@ -1,0 +1,72 @@
+<?php
+/** @var array<string,mixed> $contacto */
+/** @var array<int,array{id:int,nombre:string}> $entidades */
+
+if (!function_exists('h')) {
+    function h($value): string
+    {
+        return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+$contactId    = (int)($contacto['id'] ?? 0);
+$nombre       = $contacto['nombre'] ?? '';
+$idEntidad    = (int)($contacto['id_entidad'] ?? 0);
+$titulo       = $contacto['titulo'] ?? '';
+$cargo        = $contacto['cargo'] ?? '';
+$telefono     = $contacto['telefono'] ?? '';
+$correo       = $contacto['correo'] ?? '';
+$nota         = $contacto['nota'] ?? '';
+?>
+<section class="ent-container" aria-labelledby="editar-contacto-title">
+  <header class="ent-toolbar">
+    <div class="ent-toolbar__lead">
+      <h1 id="editar-contacto-title" class="ent-title">Editar contacto</h1>
+      <p class="ent-toolbar__caption">Modifica la información y guarda los cambios.</p>
+    </div>
+  </header>
+
+  <section class="card" aria-labelledby="form-editar-contacto">
+    <h2 id="form-editar-contacto" class="ent-title">Información del contacto</h2>
+    <form method="post" action="/comercial/contactos/<?= h((string)$contactId) ?>" class="form ent-form">
+      <div class="form-row">
+        <label for="contacto-entidad">Entidad</label>
+        <select id="contacto-entidad" name="id_entidad" required>
+          <?php foreach ($entidades as $ent): ?>
+            <option value="<?= h((string)$ent['id']) ?>" <?= $ent['id'] === $idEntidad ? 'selected' : '' ?>>
+              <?= h($ent['nombre']) ?>
+            </option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="form-row">
+        <label for="contacto-nombre">Nombre</label>
+        <input id="contacto-nombre" type="text" name="nombre" value="<?= h($nombre) ?>" required>
+      </div>
+      <div class="form-row">
+        <label for="contacto-titulo">Título</label>
+        <input id="contacto-titulo" type="text" name="titulo" value="<?= h($titulo) ?>">
+      </div>
+      <div class="form-row">
+        <label for="contacto-cargo">Cargo</label>
+        <input id="contacto-cargo" type="text" name="cargo" value="<?= h($cargo) ?>">
+      </div>
+      <div class="form-row">
+        <label for="contacto-telefono">Teléfono</label>
+        <input id="contacto-telefono" type="text" name="telefono" value="<?= h($telefono) ?>">
+      </div>
+      <div class="form-row">
+        <label for="contacto-correo">Correo</label>
+        <input id="contacto-correo" type="email" name="correo" value="<?= h($correo) ?>">
+      </div>
+      <div class="form-row">
+        <label for="contacto-nota">Nota</label>
+        <textarea id="contacto-nota" name="nota"><?= h($nota) ?></textarea>
+      </div>
+      <div class="form-actions ent-actions">
+        <button class="btn btn-primary" type="submit">Guardar cambios</button>
+        <a class="btn btn-cancel" href="/comercial/contactos">Cancelar</a>
+      </div>
+    </form>
+  </section>
+</section>

--- a/app/Views/comercial/contactos/index.php
+++ b/app/Views/comercial/contactos/index.php
@@ -52,30 +52,14 @@ function buildPageUrlContactos(int $pageNumber, array $filters, int $perPage): s
     return '/comercial/contactos' . ($queryString !== '' ? '?' . $queryString : '');
 }
 ?>
-<section class="ent-list ent-list--cards" aria-labelledby="contactos-title">
-  <header class="ent-toolbar" role="search">
+<section class="ent-list" aria-labelledby="contactos-title">
+  <header class="ent-toolbar">
     <div class="ent-toolbar__lead">
       <h1 id="contactos-title" class="ent-title">Agenda de contactos</h1>
       <p class="ent-toolbar__caption" aria-live="polite">
         <?= h((string)(int)$total) ?> contactos · Página <?= h((string)(int)$page) ?> de <?= h((string)(int)$pages) ?>
       </p>
     </div>
-    <form class="ent-search" action="/comercial/contactos" method="get">
-      <label for="contactos-search-input">Buscar contacto</label>
-      <input id="contactos-search-input" type="text" name="q" value="<?= h($q ?? '') ?>" aria-describedby="contactos-search-help" placeholder="Nombre...">
-      <?php foreach ($filters as $filterKey => $filterValue): ?>
-        <?php if ($filterKey === 'q') { continue; } ?>
-        <?php if (is_array($filterValue)): ?>
-          <?php foreach ($filterValue as $fv): ?>
-            <input type="hidden" name="<?= h((string)$filterKey) ?>[]" value="<?= h((string)$fv) ?>">
-          <?php endforeach; ?>
-        <?php else: ?>
-          <input type="hidden" name="<?= h((string)$filterKey) ?>" value="<?= h((string)$filterValue) ?>">
-        <?php endif; ?>
-      <?php endforeach; ?>
-      <span id="contactos-search-help" class="ent-search__help">Escribe al menos 3 caracteres</span>
-      <button class="btn btn-outline" type="submit">Buscar</button>
-    </form>
   </header>
 
   <section class="card ent-container" aria-labelledby="nuevo-contacto-title">
@@ -119,87 +103,72 @@ function buildPageUrlContactos(int $pageNumber, array $filters, int $perPage): s
     </form>
   </section>
 
-  <?php if (empty($items)): ?>
-    <div class="card" role="status" aria-live="polite">No se encontraron contactos.</div>
-  <?php else: ?>
-    <ul class="ent-cards-grid" role="list">
-      <?php foreach ($items as $row): ?>
-        <?php
-          $contactId   = (int)($row['id'] ?? 0);
-          $contactName = $row['nombre'] ?? 'Contacto';
-          $entityName  = $row['entidad_nombre'] ?? '';
-          $titulo      = $row['titulo'] ?? '';
-          $cargo       = $row['cargo'] ?? '';
-          $telefono    = $row['telefono'] ?? '';
-          $correo      = $row['correo'] ?? '';
-          $nota        = $row['nota'] ?? '';
-        ?>
-        <li class="ent-cards-grid__item" role="listitem">
-          <article class="ent-card" aria-labelledby="contact-card-title-<?= h((string)$contactId) ?>">
-            <header class="ent-card-head">
-              <div class="ent-card-icon" aria-hidden="true">
-                <span class="material-symbols-outlined" aria-hidden="true">person</span>
-              </div>
-              <h2 id="contact-card-title-<?= h((string)$contactId) ?>" class="ent-card-title">
-                <?= h($contactName) ?>
-              </h2>
-              <span class="ent-badge" aria-label="Entidad asociada">
-                <?= h($entityName) ?>
-              </span>
-            </header>
-            <div class="ent-card-body">
-              <div class="ent-card-row">
-                <span class="ent-card-label">Título</span>
-                <span class="ent-card-value">
-                  <?= $titulo !== '' ? h($titulo) : '—' ?>
-                </span>
-              </div>
-              <div class="ent-card-row">
-                <span class="ent-card-label">Cargo</span>
-                <span class="ent-card-value">
-                  <?= $cargo !== '' ? h($cargo) : '—' ?>
-                </span>
-              </div>
-              <div class="ent-card-row">
-                <span class="ent-card-label">Teléfono</span>
-                <span class="ent-card-value">
-                  <?= $telefono !== '' ? h($telefono) : '—' ?>
-                </span>
-              </div>
-              <div class="ent-card-row">
-                <span class="ent-card-label">Correo</span>
-                <span class="ent-card-value">
-                  <?= $correo !== '' ? h($correo) : '—' ?>
-                </span>
-              </div>
-              <div class="ent-card-row">
-                <span class="ent-card-label">Nota</span>
-                <span class="ent-card-value">
-                  <?= $nota !== '' ? h($nota) : '—' ?>
-                </span>
-              </div>
-            </div>
-            <footer class="ent-card-actions">
-              <form method="post" action="/comercial/contactos/<?= h((string)$contactId) ?>/eliminar" class="ent-card-delete" onsubmit="return confirm('¿Deseas eliminar este contacto?');">
+  <section class="ent-container ent-contactos-list" aria-labelledby="contactos-listado-title">
+    <h2 id="contactos-listado-title" class="ent-title">Listado de contactos</h2>
+    <form class="ent-search ent-search--stack" action="/comercial/contactos" method="get" role="search">
+      <label for="contactos-search-input">Buscar contacto</label>
+      <input id="contactos-search-input" type="text" name="q" value="<?= h($q ?? '') ?>" aria-describedby="contactos-search-help" placeholder="Nombre...">
+      <?php foreach ($filters as $filterKey => $filterValue): ?>
+        <?php if ($filterKey === 'q') { continue; } ?>
+        <?php if (is_array($filterValue)): ?>
+          <?php foreach ($filterValue as $fv): ?>
+            <input type="hidden" name="<?= h((string)$filterKey) ?>[]" value="<?= h((string)$fv) ?>">
+          <?php endforeach; ?>
+        <?php else: ?>
+          <input type="hidden" name="<?= h((string)$filterKey) ?>" value="<?= h((string)$filterValue) ?>">
+        <?php endif; ?>
+      <?php endforeach; ?>
+      <span id="contactos-search-help" class="ent-search__help">Escribe al menos 3 caracteres</span>
+      <button class="btn btn-outline" type="submit">Buscar</button>
+    </form>
+
+    <?php if (empty($items)): ?>
+      <div class="card" role="status" aria-live="polite">No se encontraron contactos.</div>
+    <?php else: ?>
+      <div class="contact-list" role="table" aria-label="Listado de contactos">
+        <div class="contact-list__header" role="row">
+          <span class="contact-list__cell contact-list__cell--header" role="columnheader">Nombre</span>
+          <span class="contact-list__cell contact-list__cell--header" role="columnheader">Entidad</span>
+          <span class="contact-list__cell contact-list__cell--header" role="columnheader">Cargo</span>
+          <span class="contact-list__cell contact-list__cell--header" role="columnheader">Teléfono</span>
+          <span class="contact-list__cell contact-list__cell--header contact-list__cell--actions" role="columnheader">Acciones</span>
+        </div>
+        <?php foreach ($items as $row): ?>
+          <?php
+            $contactId   = (int)($row['id'] ?? 0);
+            $contactName = $row['nombre'] ?? 'Contacto';
+            $entityName  = $row['entidad_nombre'] ?? '';
+            $cargo       = $row['cargo'] ?? '';
+            $telefono    = $row['telefono'] ?? '';
+          ?>
+          <div class="contact-list__row" role="row">
+            <span class="contact-list__cell" data-label="Nombre" role="cell"><?= h($contactName) ?></span>
+            <span class="contact-list__cell" data-label="Entidad" role="cell"><?= $entityName !== '' ? h($entityName) : '—' ?></span>
+            <span class="contact-list__cell" data-label="Cargo" role="cell"><?= $cargo !== '' ? h($cargo) : '—' ?></span>
+            <span class="contact-list__cell" data-label="Teléfono" role="cell"><?= $telefono !== '' ? h($telefono) : '—' ?></span>
+            <span class="contact-list__cell contact-list__cell--actions" data-label="Acciones" role="cell">
+              <a class="btn btn-primary" href="/comercial/contactos/editar?id=<?= h((string)$contactId) ?>" target="_blank" rel="noopener">Editar</a>
+              <form method="post" action="/comercial/contactos/<?= h((string)$contactId) ?>/eliminar" class="contact-list__delete" onsubmit="return confirm('¿Deseas eliminar este contacto?');">
                 <button type="submit" class="btn btn-danger">Eliminar</button>
               </form>
-            </footer>
-          </article>
-        </li>
-      <?php endforeach; ?>
-    </ul>
-    <nav class="pagination" aria-label="Paginación de contactos">
-      <?php if ($page > 1): ?>
-        <a href="<?= h(buildPageUrlContactos($prev, $filters, $perPage)) ?>" rel="prev">&laquo; Anterior</a>
-      <?php else: ?>
-        <span class="disabled" aria-disabled="true">&laquo; Anterior</span>
-      <?php endif; ?>
-      <span aria-live="polite">Página <?= h((string)(int)$page) ?> de <?= h((string)(int)$pages) ?></span>
-      <?php if ($page < $pages): ?>
-        <a href="<?= h(buildPageUrlContactos($next, $filters, $perPage)) ?>" rel="next">Siguiente &raquo;</a>
-      <?php else: ?>
-        <span class="disabled" aria-disabled="true">Siguiente &raquo;</span>
-      <?php endif; ?>
-    </nav>
-  <?php endif; ?>
+            </span>
+          </div>
+        <?php endforeach; ?>
+      </div>
+
+      <nav class="pagination" aria-label="Paginación de contactos">
+        <?php if ($page > 1): ?>
+          <a href="<?= h(buildPageUrlContactos($prev, $filters, $perPage)) ?>" rel="prev">&laquo; Anterior</a>
+        <?php else: ?>
+          <span class="disabled" aria-disabled="true">&laquo; Anterior</span>
+        <?php endif; ?>
+        <span aria-live="polite">Página <?= h((string)(int)$page) ?> de <?= h((string)(int)$pages) ?></span>
+        <?php if ($page < $pages): ?>
+          <a href="<?= h(buildPageUrlContactos($next, $filters, $perPage)) ?>" rel="next">Siguiente &raquo;</a>
+        <?php else: ?>
+          <span class="disabled" aria-disabled="true">Siguiente &raquo;</span>
+        <?php endif; ?>
+      </nav>
+    <?php endif; ?>
+  </section>
 </section>

--- a/config/routes.php
+++ b/config/routes.php
@@ -75,6 +75,16 @@ $router->post(
     [ContactosController::class, 'create'],
     ['middleware'=>['auth','role:comercial']]
 );
+$router->get(
+    '/comercial/contactos/editar',
+    [ContactosController::class, 'editForm'],
+    ['middleware'=>['auth','role:comercial']]
+);
+$router->post(
+    '/comercial/contactos/{id}',
+    [ContactosController::class, 'update'],
+    ['middleware'=>['auth','role:comercial']]
+);
 $router->post(
     '/comercial/contactos/{id}/eliminar',
     [ContactosController::class, 'delete'],

--- a/public/css/comercial_style/comercial-entidades.css
+++ b/public/css/comercial_style/comercial-entidades.css
@@ -144,8 +144,18 @@
 .ent-toolbar{
   display:flex; gap:10px; align-items:center; flex-wrap:wrap; margin: 14px 0;
 }
-.ent-search{
+.ent-search{ 
   display:flex; gap:6px; align-items:center;
+}
+.ent-search--stack{
+  flex-wrap:wrap;
+  align-items:flex-end;
+  gap:10px;
+  margin: 18px 0 24px;
+}
+.ent-search--stack label{
+  font-weight:700;
+  color:var(--text-body, #111827);
 }
 .ent-search input[type="text"]{
   width:min(280px, 60vw);
@@ -180,6 +190,93 @@
 
 /* Número centrado */
 .ent-table .col-num { text-align:center; color:#6b7280; width: 68px; }
+
+.ent-contactos-list{ margin-top: 32px; }
+
+.contact-list{
+  width:100%;
+  border:1px solid #e5e7eb;
+  border-radius:12px;
+  overflow:hidden;
+  background:#fff;
+  box-shadow:0 1px 3px rgba(15,23,42,.08);
+}
+.contact-list__header,
+.contact-list__row{
+  display:grid;
+  grid-template-columns: minmax(180px, 2fr) minmax(160px, 1.6fr) minmax(140px, 1.4fr) minmax(140px, 1.3fr) minmax(160px, 1.1fr);
+  gap:0;
+  align-items:center;
+}
+.contact-list__header{
+  background: var(--table-header-bg, var(--color-secondary));
+  color: var(--table-header-text, #fff);
+  font-weight:700;
+  font-size:.95rem;
+}
+.contact-list__cell{
+  padding:.75rem .9rem;
+  border-top:1px solid #eef2f6;
+  font-size:.95rem;
+  color: var(--table-row-text, #0f172a);
+}
+.contact-list__header .contact-list__cell{
+  border-top:none;
+}
+.contact-list__row:nth-of-type(odd){
+  background: var(--table-row-bg, #f9fafb);
+}
+.contact-list__row:hover{
+  background: var(--table-row-hover, #FFFAF5);
+}
+.contact-list__cell--actions{
+  display:flex;
+  gap:12px;
+  align-items:center;
+  justify-content:flex-start;
+  flex-wrap:wrap;
+}
+.contact-list__cell--header{
+  text-transform:uppercase;
+  letter-spacing:.03em;
+}
+.contact-list__delete{
+  display:inline;
+}
+.contact-list__delete .btn{
+  padding:.55rem .85rem;
+}
+@media (max-width: 900px){
+  .contact-list__header,
+  .contact-list__row{
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .contact-list__header{
+    display:none;
+  }
+  .contact-list__row{
+    border-bottom:1px solid #e5e7eb;
+    padding:.45rem 0;
+  }
+  .contact-list__cell{
+    border:none;
+    padding:.55rem .75rem;
+    display:flex;
+    flex-direction:column;
+    gap:4px;
+  }
+  .contact-list__cell--actions{
+    flex-direction:row;
+  }
+  .contact-list__cell::before{
+    content: attr(data-label);
+    font-size:.80rem;
+    font-weight:700;
+    color:#6b7280;
+    text-transform:uppercase;
+    letter-spacing:.02em;
+  }
+}
 
 /* Estado como “píldora” */
 .status-pill{


### PR DESCRIPTION
## Summary
- reorganize the contact agenda page to show a searchable list view with a dedicated "Listado de contactos" heading
- add controller, route, repository and view support for editing existing contacts in a separate form
- update shared commercial styles to support the new list layout and responsive behaviour

## Testing
- php -l app/Repositories/Comercial/ContactoRepository.php
- php -l app/Controllers/Comercial/ContactosController.php
- php -l app/Views/comercial/contactos/index.php
- php -l app/Views/comercial/contactos/edit.php

------
https://chatgpt.com/codex/tasks/task_e_68dee32de4d8832688c79585a66ed42f