### PR TITLE
Add commercial dashboard analytics cards and charts

### DIFF
--- a/app/Controllers/Comercial/ContactosController.php
+++ b/app/Controllers/Comercial/ContactosController.php
@@ -57,6 +57,55 @@ final class ContactosController
     }
 
     /**
+     * Devuelve sugerencias de búsqueda para el cuadro de texto principal.
+     */
+    public function suggest(): void
+    {
+        $q = isset($_GET['q']) ? trim((string)$_GET['q']) : '';
+        if (mb_strlen($q) < 3) {
+            $this->respondJson(['items' => []]);
+        }
+
+        try {
+            $rows = $this->repo->suggest($q, 12);
+        } catch (\Throwable $e) {
+            $this->respondJson(['items' => [], 'error' => 'No se pudo obtener sugerencias'], 500);
+        }
+
+        $contactItems = [];
+        $entityItems  = [];
+
+        foreach ($rows as $row) {
+            $nombre  = trim((string)($row['nombre'] ?? ''));
+            $entidad = trim((string)($row['entidad_nombre'] ?? ''));
+
+            if ($entidad !== '' && !isset($entityItems[$entidad])) {
+                $entityItems[$entidad] = [
+                    'type' => 'entity',
+                    'term' => $entidad,
+                    'label'=> 'Entidad · ' . $entidad,
+                ];
+            }
+
+            if ($nombre !== '') {
+                $contactItems[] = [
+                    'type'    => 'contact',
+                    'term'    => $nombre,
+                    'label'   => $nombre . ($entidad !== '' ? ' · ' . $entidad : ''),
+                    'cargo'   => (string)($row['cargo'] ?? ''),
+                    'entidad' => $entidad,
+                ];
+            }
+        }
+
+        $entities   = array_slice(array_values($entityItems), 0, 5);
+        $contacts   = array_slice($contactItems, 0, 7);
+        $items      = array_merge($entities, $contacts);
+
+        $this->respondJson(['items' => $items]);
+    }
+
+    /**
      * Maneja la creación de un contacto a partir de los datos del POST.
      */
     public function create()
@@ -71,6 +120,57 @@ final class ContactosController
             'nota'              => trim((string)($_POST['nota'] ?? '')),
         ];
         $this->repo->create($data);
+        redirect('/comercial/contactos');
+    }
+
+    /**
+     * Muestra el formulario para editar un contacto existente.
+     */
+    public function editForm()
+    {
+        $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+        if ($id < 1) {
+            redirect('/comercial/contactos');
+            return;
+        }
+
+        $contacto = $this->repo->find($id);
+        if ($contacto === null) {
+            redirect('/comercial/contactos');
+            return;
+        }
+
+        return view('comercial/contactos/edit', [
+            'layout'    => 'layout',
+            'title'     => 'Editar contacto',
+            'contacto'  => $contacto,
+            'entidades' => $this->listadoEntidades(),
+        ]);
+    }
+
+    /**
+     * Actualiza un contacto.
+     *
+     * @param int|string $id
+     */
+    public function update($id)
+    {
+        $id = (int)$id;
+        if ($id < 1) {
+            redirect('/comercial/contactos');
+            return;
+        }
+
+        $data = [
+            'id_cooperativa'    => (int)($_POST['id_entidad'] ?? 0),
+            'nombre'            => trim((string)($_POST['nombre'] ?? '')),
+            'titulo'            => trim((string)($_POST['titulo'] ?? '')),
+            'cargo'             => trim((string)($_POST['cargo'] ?? '')),
+            'telefono_contacto' => trim((string)($_POST['telefono'] ?? '')),
+            'email_contacto'    => trim((string)($_POST['correo'] ?? '')),
+            'nota'              => trim((string)($_POST['nota'] ?? '')),
+        ];
+        $this->repo->update($id, $data);
         redirect('/comercial/contactos');
     }
 
@@ -111,5 +211,18 @@ final class ContactosController
             ];
         }
         return $list;
+    }
+
+    /**
+     * Envía una respuesta JSON y termina la ejecución.
+     *
+     * @param array<string,mixed> $payload
+     */
+    private function respondJson(array $payload, int $status = 200): void
+    {
+        http_response_code($status);
+        header('Content-Type: application/json; charset=UTF-8');
+        echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+        exit;
     }
 }

--- a/app/Controllers/Comercial/DashboardController.php
+++ b/app/Controllers/Comercial/DashboardController.php
@@ -2,9 +2,9 @@
 namespace App\Controllers\Comercial;
 
 use App\Services\Shared\Breadcrumbs;
-use App\Services\Shared\MetricsService;
 use App\Services\Shared\Pagination;
 use App\Services\Comercial\BuscarEntidadesService;
+use App\Services\Comercial\DashboardService;
 
 final class DashboardController
 {
@@ -14,8 +14,22 @@ final class DashboardController
       ['href'=>'/comercial', 'label'=>'Comercial'],
       ['label'=>'Dashboard']
     ]);
-    $metrics = (new MetricsService())->forModule('comercial'); // placeholder
-    view('comercial/dashboard/index', compact('crumbs','metrics') + ['title'=>'Comercial · Dashboard']);
+    $service = new DashboardService();
+    $error   = null;
+    $stats   = array('cards'=>array(), 'segmentos'=>array(), 'estado'=>array('activas'=>0,'inactivas'=>0), 'mensual'=>array('labels'=>array(), 'counts'=>array()));
+
+    try {
+      $stats = $service->obtenerEstadisticas();
+    } catch (\Throwable $e) {
+      $error = 'Error al cargar datos estadísticos: ' . $e->getMessage();
+    }
+
+    view('comercial/dashboard/index', [
+      'title'    => 'Comercial · Dashboard',
+      'crumbs'   => $crumbs,
+      'stats'    => $stats,
+      'error'    => $error,
+    ]);
   }
 
   // Ejemplo: listado paginado de Entidades Financieras

--- a/app/Repositories/Comercial/ContactoRepository.php
+++ b/app/Repositories/Comercial/ContactoRepository.php
@@ -62,6 +62,7 @@ final class ContactoRepository extends BaseRepository
             WHERE (
                 :has_q = 0
                 OR unaccent(lower(' . $nombreExpr . ')) LIKE unaccent(lower(:like))
+                OR unaccent(lower(e.' . self::COL_COOP_NOMBRE . ')) LIKE unaccent(lower(:like))
             )
         ';
         $bindings = [
@@ -101,6 +102,7 @@ final class ContactoRepository extends BaseRepository
             WHERE (
                 :has_q = 0
                 OR unaccent(lower(' . $nombreExpr . ')) LIKE unaccent(lower(:like))
+                OR unaccent(lower(e.' . self::COL_COOP_NOMBRE . ')) LIKE unaccent(lower(:like))
             )
             ORDER BY ' . $nombreExpr . '
             LIMIT :limit OFFSET :offset
@@ -119,6 +121,122 @@ final class ContactoRepository extends BaseRepository
             'total'   => $total,
             'page'    => $page,
             'perPage' => $perPage,
+        ];
+    }
+
+    /**
+     * Devuelve sugerencias rápidas para el cuadro de búsqueda.
+     *
+     * @param string $q     Texto a buscar.
+     * @param int    $limit Límite máximo de registros.
+     * @return array<int,array<string,mixed>>
+     */
+    public function suggest(string $q, int $limit = 8): array
+    {
+        $q = trim($q);
+        if ($q === '') {
+            return [];
+        }
+
+        $limit = max(1, min(20, $limit));
+        $like  = '%' . $q . '%';
+        $nombreExpr = "COALESCE(c." . self::COL_NOMBRE_RAW . ", c." . self::COL_CONTACTO_ALT . ")";
+
+        $sql = '
+            SELECT
+                c.' . self::COL_ID . ' AS id,
+                c.' . self::COL_COOP . ' AS id_entidad,
+                e.' . self::COL_COOP_NOMBRE . ' AS entidad_nombre,
+                ' . $nombreExpr . ' AS nombre,
+                c.' . self::COL_CARGO . ' AS cargo
+            FROM ' . self::T_CONTACTO . ' c
+            INNER JOIN ' . self::T_COOP . ' e
+                ON e.' . self::COL_COOP_ID . ' = c.' . self::COL_COOP . '
+            WHERE (
+                unaccent(lower(' . $nombreExpr . ')) LIKE unaccent(lower(:like))
+                OR unaccent(lower(e.' . self::COL_COOP_NOMBRE . ')) LIKE unaccent(lower(:like))
+            )
+            ORDER BY ' . $nombreExpr . '
+            LIMIT :limit
+        ';
+
+        $params = [
+            ':like'  => [$like, PDO::PARAM_STR],
+            ':limit' => [$limit, PDO::PARAM_INT],
+        ];
+
+        try {
+            $rows = $this->db->fetchAll($sql, $params);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('Error al obtener sugerencias de contactos.', 0, $e);
+        }
+
+        $suggestions = [];
+        foreach ($rows as $row) {
+            $suggestions[] = [
+                'id'             => isset($row['id']) ? (int)$row['id'] : null,
+                'id_entidad'     => isset($row['id_entidad']) ? (int)$row['id_entidad'] : null,
+                'entidad_nombre' => (string)($row['entidad_nombre'] ?? ''),
+                'nombre'         => (string)($row['nombre'] ?? ''),
+                'cargo'          => (string)($row['cargo'] ?? ''),
+            ];
+        }
+
+        return $suggestions;
+    }
+
+    /**
+     * Obtiene un contacto por su identificador.
+     *
+     * @param int $id
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        if ($id < 1) {
+            return null;
+        }
+
+        $nombreExpr = "COALESCE(c." . self::COL_NOMBRE_RAW . ", c." . self::COL_CONTACTO_ALT . ")";
+
+        $sql = '
+            SELECT
+                c.' . self::COL_ID . ' AS id,
+                c.' . self::COL_COOP . ' AS id_entidad,
+                e.' . self::COL_COOP_NOMBRE . ' AS entidad_nombre,
+                ' . $nombreExpr . ' AS nombre,
+                c.' . self::COL_TITULO . ' AS titulo,
+                c.' . self::COL_CARGO . ' AS cargo,
+                c.' . self::COL_TEL . ' AS telefono,
+                c.' . self::COL_MAIL . ' AS correo,
+                c.' . self::COL_NOTA . ' AS nota
+            FROM ' . self::T_CONTACTO . ' c
+            INNER JOIN ' . self::T_COOP . ' e
+                ON e.' . self::COL_COOP_ID . ' = c.' . self::COL_COOP . '
+            WHERE c.' . self::COL_ID . ' = :id
+            LIMIT 1
+        ';
+
+        try {
+            $row = $this->db->fetch($sql, [':id' => [$id, PDO::PARAM_INT]]);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('Error al obtener el contacto.', 0, $e);
+        }
+
+        if (!$row) {
+            return null;
+        }
+
+        return [
+            'id'             => isset($row['id']) ? (int)$row['id'] : $id,
+            'id_entidad'     => isset($row['id_entidad']) ? (int)$row['id_entidad'] : null,
+            'entidad_nombre' => (string)($row['entidad_nombre'] ?? ''),
+            'nombre'         => (string)($row['nombre'] ?? ''),
+            'titulo'         => (string)($row['titulo'] ?? ''),
+            'cargo'          => (string)($row['cargo'] ?? ''),
+            'telefono'       => (string)($row['telefono'] ?? ''),
+            'correo'         => (string)($row['correo'] ?? ''),
+            'nota'           => (string)($row['nota'] ?? ''),
         ];
     }
 

--- a/app/Repositories/Comercial/DashboardRepository.php
+++ b/app/Repositories/Comercial/DashboardRepository.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Repositories\Comercial;
+
+use App\Repositories\BaseRepository;
+use PDO;
+
+final class DashboardRepository extends BaseRepository
+{
+    private const T_COOP        = 'public.cooperativas';
+    private const COL_ID        = 'id_cooperativa';
+    private const COL_SEGMENTO  = 'id_segmento';
+    private const COL_ACTIVA    = 'activa';
+    private const COL_FECHA_REG = 'fecha_registro';
+
+    private const T_SEGMENTO    = 'public.segmentos';
+    private const SEG_ID        = 'id_segmento';
+    private const SEG_NOMBRE    = 'nombre_segmento';
+
+    public function totalCooperativas(): int
+    {
+        $sql = 'SELECT COUNT(*) AS total FROM ' . self::T_COOP;
+        $row = $this->db->fetch($sql);
+
+        return isset($row['total']) ? (int)$row['total'] : 0;
+    }
+
+    /**
+     * @return array<int,array{nombre_segmento:string,cantidad:int}>
+     */
+    public function cooperativasPorSegmento(): array
+    {
+        $sql = implode("\n", array(
+            'SELECT',
+            '    COALESCE(seg.' . self::SEG_NOMBRE . ', ' . "'Sin segmento'" . ') AS nombre_segmento,',
+            '    COUNT(c.' . self::COL_ID . ') AS cantidad',
+            'FROM ' . self::T_COOP . ' c',
+            'LEFT JOIN ' . self::T_SEGMENTO . ' seg',
+            '  ON seg.' . self::SEG_ID . ' = c.' . self::COL_SEGMENTO,
+            'GROUP BY 1',
+            'ORDER BY 1'
+        ));
+
+        $rows = $this->db->fetchAll($sql);
+
+        $data = array();
+        foreach ($rows as $row) {
+            $nombre = isset($row['nombre_segmento']) ? (string)$row['nombre_segmento'] : 'Sin segmento';
+            $cantidad = isset($row['cantidad']) ? (int)$row['cantidad'] : 0;
+            $data[] = array(
+                'nombre_segmento' => $nombre,
+                'cantidad'        => $cantidad,
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array{activas:int,inactivas:int}
+     */
+    public function cooperativasPorEstado(): array
+    {
+        $sql = implode("\n", array(
+            'SELECT',
+            '    COUNT(*) FILTER (WHERE c.' . self::COL_ACTIVA . ' IS TRUE) AS activas,',
+            '    COUNT(*) FILTER (WHERE c.' . self::COL_ACTIVA . ' IS DISTINCT FROM TRUE) AS inactivas',
+            'FROM ' . self::T_COOP . ' c'
+        ));
+
+        $row = $this->db->fetch($sql) ?: array();
+
+        return array(
+            'activas'   => isset($row['activas']) ? (int)$row['activas'] : 0,
+            'inactivas' => isset($row['inactivas']) ? (int)$row['inactivas'] : 0,
+        );
+    }
+
+    /**
+     * @return array<int,array{mes:string,cantidad:int}>
+     */
+    public function registrosMensuales(int $months): array
+    {
+        $months = max(1, $months);
+
+        $sql = implode("\n", array(
+            'SELECT',
+            "    to_char(date_trunc('month', c." . self::COL_FECHA_REG . "), 'YYYY-MM') AS mes,",
+            '    COUNT(*) AS cantidad',
+            'FROM ' . self::T_COOP . ' c',
+            'WHERE c.' . self::COL_FECHA_REG . ' >= (CURRENT_DATE - make_interval(months => :months))',
+            'GROUP BY date_trunc(\'month\', c.' . self::COL_FECHA_REG . ')',
+            'ORDER BY date_trunc(\'month\', c.' . self::COL_FECHA_REG . ')'
+        ));
+
+        $rows = $this->db->fetchAll($sql, array(
+            ':months' => array($months, PDO::PARAM_INT),
+        ));
+
+        $data = array();
+        foreach ($rows as $row) {
+            $mes = isset($row['mes']) ? (string)$row['mes'] : '';
+            $cantidad = isset($row['cantidad']) ? (int)$row['cantidad'] : 0;
+            if ($mes === '') {
+                continue;
+            }
+            $data[] = array(
+                'mes'      => $mes,
+                'cantidad' => $cantidad,
+            );
+        }
+
+        return $data;
+    }
+}

--- a/app/Services/Comercial/DashboardService.php
+++ b/app/Services/Comercial/DashboardService.php
@@ -1,0 +1,108 @@
+<?php
+namespace App\Services\Comercial;
+
+use App\Repositories\Comercial\DashboardRepository;
+use RuntimeException;
+
+final class DashboardService
+{
+    private DashboardRepository $repository;
+
+    public function __construct(?DashboardRepository $repository = null)
+    {
+        $this->repository = $repository ?? new DashboardRepository();
+    }
+
+    /**
+     * @return array{
+     *   cards: array{
+     *     total:int,
+     *     activas:int,
+     *     inactivas:int,
+     *     porcentaje_activas:int,
+     *     porcentaje_inactivas:int,
+     *     ultimo_mes:int,
+     *     variacion:string
+     *   },
+     *   segmentos: array<int,array{nombre_segmento:string,cantidad:int}>,
+     *   estado: array{activas:int,inactivas:int},
+     *   mensual: array{labels:array<int,string>,counts:array<int,int>}
+     * }
+     */
+    public function obtenerEstadisticas(): array
+    {
+        try {
+            $total      = $this->repository->totalCooperativas();
+            $estado     = $this->repository->cooperativasPorEstado();
+            $segmentos  = $this->repository->cooperativasPorSegmento();
+            $mensuales  = $this->repository->registrosMensuales(6);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('Error al obtener métricas del dashboard', 0, $e);
+        }
+
+        $activas   = isset($estado['activas']) ? (int)$estado['activas'] : 0;
+        $inactivas = isset($estado['inactivas']) ? (int)$estado['inactivas'] : 0;
+
+        $porcentajeActivas   = $total > 0 ? (int)round(($activas / $total) * 100) : 0;
+        $porcentajeInactivas = $total > 0 ? (int)round(($inactivas / $total) * 100) : 0;
+
+        $mensualLabels = array();
+        $mensualCounts = array();
+        $meses = array('enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre');
+
+        foreach ($mensuales as $row) {
+            $mesRaw  = isset($row['mes']) ? (string)$row['mes'] : '';
+            $cantidad = isset($row['cantidad']) ? (int)$row['cantidad'] : 0;
+            if ($mesRaw === '' || strpos($mesRaw, '-') === false) {
+                continue;
+            }
+            $parts = explode('-', $mesRaw);
+            if (count($parts) !== 2) {
+                continue;
+            }
+            $yy = $parts[0];
+            $mm = (int)$parts[1];
+            $indice = $mm >= 1 && $mm <= 12 ? $mm - 1 : null;
+            if ($indice === null) {
+                continue;
+            }
+            $mensualLabels[] = $meses[$indice] . ' ' . $yy;
+            $mensualCounts[] = $cantidad;
+        }
+
+        $countMens    = count($mensualCounts);
+        $ultimoMesCnt = $countMens > 0 ? $mensualCounts[$countMens - 1] : 0;
+        $variacionStr = 'Nuevo registro';
+        if ($countMens > 1) {
+            $actual = $mensualCounts[$countMens - 1];
+            $previo = $mensualCounts[$countMens - 2];
+            if ($previo !== 0) {
+                $cambio = (int)round((($actual - $previo) / $previo) * 100);
+            } else {
+                $cambio = $actual > 0 ? 100 : 0;
+            }
+            $variacionStr = abs($cambio) . '% ' . ($cambio >= 0 ? '↑' : '↓');
+        }
+
+        return array(
+            'cards' => array(
+                'total'                 => $total,
+                'activas'               => $activas,
+                'inactivas'             => $inactivas,
+                'porcentaje_activas'    => $porcentajeActivas,
+                'porcentaje_inactivas'  => $porcentajeInactivas,
+                'ultimo_mes'            => $ultimoMesCnt,
+                'variacion'             => $variacionStr,
+            ),
+            'segmentos' => $segmentos,
+            'estado'    => array(
+                'activas'   => $activas,
+                'inactivas' => $inactivas,
+            ),
+            'mensual'   => array(
+                'labels' => $mensualLabels,
+                'counts' => $mensualCounts,
+            ),
+        );
+    }
+}

--- a/app/Views/comercial/contactos/edit.php
+++ b/app/Views/comercial/contactos/edit.php
@@ -1,0 +1,72 @@
+<?php
+/** @var array<string,mixed> $contacto */
+/** @var array<int,array{id:int,nombre:string}> $entidades */
+
+if (!function_exists('h')) {
+    function h($value): string
+    {
+        return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+$contactId    = (int)($contacto['id'] ?? 0);
+$nombre       = $contacto['nombre'] ?? '';
+$idEntidad    = (int)($contacto['id_entidad'] ?? 0);
+$titulo       = $contacto['titulo'] ?? '';
+$cargo        = $contacto['cargo'] ?? '';
+$telefono     = $contacto['telefono'] ?? '';
+$correo       = $contacto['correo'] ?? '';
+$nota         = $contacto['nota'] ?? '';
+?>
+<section class="ent-container" aria-labelledby="editar-contacto-title">
+  <header class="ent-toolbar">
+    <div class="ent-toolbar__lead">
+      <h1 id="editar-contacto-title" class="ent-title">Editar contacto</h1>
+      <p class="ent-toolbar__caption">Modifica la información y guarda los cambios.</p>
+    </div>
+  </header>
+
+  <section class="card" aria-labelledby="form-editar-contacto">
+    <h2 id="form-editar-contacto" class="ent-title">Información del contacto</h2>
+    <form method="post" action="/comercial/contactos/<?= h((string)$contactId) ?>" class="form ent-form">
+      <div class="form-row">
+        <label for="contacto-entidad">Entidad</label>
+        <select id="contacto-entidad" name="id_entidad" required>
+          <?php foreach ($entidades as $ent): ?>
+            <option value="<?= h((string)$ent['id']) ?>" <?= $ent['id'] === $idEntidad ? 'selected' : '' ?>>
+              <?= h($ent['nombre']) ?>
+            </option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="form-row">
+        <label for="contacto-nombre">Nombre</label>
+        <input id="contacto-nombre" type="text" name="nombre" value="<?= h($nombre) ?>" required>
+      </div>
+      <div class="form-row">
+        <label for="contacto-titulo">Título</label>
+        <input id="contacto-titulo" type="text" name="titulo" value="<?= h($titulo) ?>">
+      </div>
+      <div class="form-row">
+        <label for="contacto-cargo">Cargo</label>
+        <input id="contacto-cargo" type="text" name="cargo" value="<?= h($cargo) ?>">
+      </div>
+      <div class="form-row">
+        <label for="contacto-telefono">Teléfono</label>
+        <input id="contacto-telefono" type="text" name="telefono" value="<?= h($telefono) ?>">
+      </div>
+      <div class="form-row">
+        <label for="contacto-correo">Correo</label>
+        <input id="contacto-correo" type="email" name="correo" value="<?= h($correo) ?>">
+      </div>
+      <div class="form-row">
+        <label for="contacto-nota">Nota</label>
+        <textarea id="contacto-nota" name="nota"><?= h($nota) ?></textarea>
+      </div>
+      <div class="form-actions ent-actions">
+        <button class="btn btn-primary" type="submit">Guardar cambios</button>
+        <a class="btn btn-cancel" href="/comercial/contactos">Cancelar</a>
+      </div>
+    </form>
+  </section>
+</section>

--- a/app/Views/comercial/contactos/index.php
+++ b/app/Views/comercial/contactos/index.php
@@ -52,17 +52,23 @@ function buildPageUrlContactos(int $pageNumber, array $filters, int $perPage): s
     return '/comercial/contactos' . ($queryString !== '' ? '?' . $queryString : '');
 }
 ?>
-<section class="ent-list ent-list--cards" aria-labelledby="contactos-title">
-  <header class="ent-toolbar" role="search">
+<section class="ent-list" aria-labelledby="contactos-title">
+  <header class="ent-toolbar">
     <div class="ent-toolbar__lead">
       <h1 id="contactos-title" class="ent-title">Agenda de contactos</h1>
       <p class="ent-toolbar__caption" aria-live="polite">
         <?= h((string)(int)$total) ?> contactos · Página <?= h((string)(int)$page) ?> de <?= h((string)(int)$pages) ?>
       </p>
     </div>
-    <form class="ent-search" action="/comercial/contactos" method="get">
-      <label for="contactos-search-input">Buscar contacto</label>
-      <input id="contactos-search-input" type="text" name="q" value="<?= h($q ?? '') ?>" aria-describedby="contactos-search-help" placeholder="Nombre...">
+  </header>
+
+  <section class="ent-container ent-contactos-list" aria-label="Contactos registrados">
+    <form class="ent-search ent-search--stack ent-search--with-modal" action="/comercial/contactos" method="get" role="search">
+      <div class="ent-search__field">
+        <label for="contactos-search-input">Buscar por nombre o entidad</label>
+        <input id="contactos-search-input" type="text" name="q" value="<?= h($q ?? '') ?>" aria-describedby="contactos-search-help" placeholder="Nombre o entidad" autocomplete="off" autocapitalize="none" spellcheck="false">
+        <div id="contactos-search-suggestions" class="ent-search__suggestions" data-min-chars="3" role="listbox" aria-label="Sugerencias de búsqueda" hidden></div>
+      </div>
       <?php foreach ($filters as $filterKey => $filterValue): ?>
         <?php if ($filterKey === 'q') { continue; } ?>
         <?php if (is_array($filterValue)): ?>
@@ -73,133 +79,222 @@ function buildPageUrlContactos(int $pageNumber, array $filters, int $perPage): s
           <input type="hidden" name="<?= h((string)$filterKey) ?>" value="<?= h((string)$filterValue) ?>">
         <?php endif; ?>
       <?php endforeach; ?>
-      <span id="contactos-search-help" class="ent-search__help">Escribe al menos 3 caracteres</span>
-      <button class="btn btn-outline" type="submit">Buscar</button>
+      <span id="contactos-search-help" class="ent-search__help">Escribe al menos 3 caracteres para ver sugerencias</span>
+      <div class="ent-search__actions">
+        <button class="btn btn-outline" type="submit">Buscar</button>
+        <button class="btn btn-primary ent-search__new" type="button" data-modal-open="contacto-crear-modal">
+          <span class="material-symbols-outlined" aria-hidden="true">add</span>
+          <span>Nuevo contacto</span>
+        </button>
+      </div>
     </form>
-  </header>
 
-  <section class="card ent-container" aria-labelledby="nuevo-contacto-title">
-    <h2 id="nuevo-contacto-title" class="ent-title">Nuevo contacto</h2>
-    <form method="post" action="/comercial/contactos" class="form ent-form">
+    <?php if (empty($items)): ?>
+      <div class="card" role="status" aria-live="polite">No se encontraron contactos.</div>
+    <?php else: ?>
+      <?php $rowOffset = ($page - 1) * $perPage; ?>
+      <div class="contact-list" role="table" aria-label="Listado de contactos">
+        <div class="contact-list__header" role="row">
+          <span class="contact-list__cell contact-list__cell--header contact-list__cell--num" role="columnheader">#</span>
+          <span class="contact-list__cell contact-list__cell--header" role="columnheader">Nombre</span>
+          <span class="contact-list__cell contact-list__cell--header" role="columnheader">Entidad</span>
+          <span class="contact-list__cell contact-list__cell--header" role="columnheader">Cargo</span>
+          <span class="contact-list__cell contact-list__cell--header" role="columnheader">Teléfono</span>
+          <span class="contact-list__cell contact-list__cell--header contact-list__cell--actions" role="columnheader">Acciones</span>
+        </div>
+        <?php foreach ($items as $index => $row): ?>
+          <?php
+            $contactId   = (int)($row['id'] ?? 0);
+            $contactName = $row['nombre'] ?? 'Contacto';
+            $entityName  = $row['entidad_nombre'] ?? '';
+            $cargo       = $row['cargo'] ?? '';
+            $telefono    = $row['telefono'] ?? '';
+            $titulo      = $row['titulo'] ?? '';
+            $correo      = $row['correo'] ?? '';
+            $nota        = $row['nota'] ?? '';
+            $rowNumber   = $rowOffset + $index + 1;
+            $detailsId   = 'contact-details-' . ($contactId > 0 ? $contactId : ('row-' . $rowNumber));
+          ?>
+          <div class="contact-list__row" role="row">
+            <span class="contact-list__cell contact-list__cell--num" data-label="Detalle" role="cell">
+              <button type="button" class="contact-list__toggle" data-contact-toggle
+                      aria-expanded="false" aria-controls="<?= h($detailsId) ?>">
+                <?= h((string)$rowNumber) ?>
+              </button>
+            </span>
+            <span class="contact-list__cell" data-label="Nombre" role="cell"><?= h($contactName) ?></span>
+            <span class="contact-list__cell" data-label="Entidad" role="cell"><?= $entityName !== '' ? h($entityName) : '—' ?></span>
+            <span class="contact-list__cell" data-label="Cargo" role="cell"><?= $cargo !== '' ? h($cargo) : '—' ?></span>
+            <span class="contact-list__cell" data-label="Teléfono" role="cell"><?= $telefono !== '' ? h($telefono) : '—' ?></span>
+            <span class="contact-list__cell contact-list__cell--actions" data-label="Acciones" role="cell">
+              <button
+                class="btn btn-primary"
+                type="button"
+                data-contact-edit
+                data-modal-open="contacto-editar-modal"
+                data-contact-id="<?= h((string)$contactId) ?>"
+                data-contact-entidad="<?= isset($row['id_entidad']) ? h((string)$row['id_entidad']) : '' ?>"
+                data-contact-nombre="<?= h($contactName) ?>"
+                data-contact-titulo="<?= h($titulo) ?>"
+                data-contact-cargo="<?= h($cargo) ?>"
+                data-contact-telefono="<?= h($telefono) ?>"
+                data-contact-correo="<?= h($correo) ?>"
+                data-contact-nota="<?= h($nota) ?>"
+              >
+                Editar
+              </button>
+              <form method="post" action="/comercial/contactos/<?= h((string)$contactId) ?>/eliminar" class="contact-list__delete" onsubmit="return confirm('¿Deseas eliminar este contacto?');">
+                <button type="submit" class="btn btn-danger">Eliminar</button>
+              </form>
+            </span>
+          </div>
+          <div class="contact-list__details" id="<?= h($detailsId) ?>" role="row" aria-hidden="true" hidden>
+            <div class="contact-list__cell contact-list__cell--details" role="cell" data-label="Detalles">
+              <dl class="contact-details">
+                <div class="contact-details__item">
+                  <dt>Nombre</dt>
+                  <dd><?= h($contactName) ?></dd>
+                </div>
+                <div class="contact-details__item">
+                  <dt>Entidad</dt>
+                  <dd><?= $entityName !== '' ? h($entityName) : '—' ?></dd>
+                </div>
+                <div class="contact-details__item">
+                  <dt>Título</dt>
+                  <dd><?= $titulo !== '' ? h($titulo) : '—' ?></dd>
+                </div>
+                <div class="contact-details__item">
+                  <dt>Cargo</dt>
+                  <dd><?= $cargo !== '' ? h($cargo) : '—' ?></dd>
+                </div>
+                <div class="contact-details__item">
+                  <dt>Teléfono</dt>
+                  <dd><?= $telefono !== '' ? h($telefono) : '—' ?></dd>
+                </div>
+                <div class="contact-details__item">
+                  <dt>Correo</dt>
+                  <dd><?= $correo !== '' ? h($correo) : '—' ?></dd>
+                </div>
+                <div class="contact-details__item contact-details__item--full">
+                  <dt>Nota</dt>
+                  <dd><?= $nota !== '' ? nl2br(h($nota)) : '—' ?></dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        <?php endforeach; ?>
+      </div>
+
+      <nav class="pagination" aria-label="Paginación de contactos">
+        <?php if ($page > 1): ?>
+          <a href="<?= h(buildPageUrlContactos($prev, $filters, $perPage)) ?>" rel="prev">&laquo; Anterior</a>
+        <?php else: ?>
+          <span class="disabled" aria-disabled="true">&laquo; Anterior</span>
+        <?php endif; ?>
+        <span aria-live="polite">Página <?= h((string)(int)$page) ?> de <?= h((string)(int)$pages) ?></span>
+        <?php if ($page < $pages): ?>
+          <a href="<?= h(buildPageUrlContactos($next, $filters, $perPage)) ?>" rel="next">Siguiente &raquo;</a>
+        <?php else: ?>
+          <span class="disabled" aria-disabled="true">Siguiente &raquo;</span>
+        <?php endif; ?>
+      </nav>
+    <?php endif; ?>
+  </section>
+</section>
+<div class="contact-modal" id="contacto-crear-modal" data-modal hidden aria-hidden="true">
+  <div class="contact-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="nuevo-contacto-modal-title" tabindex="-1" data-modal-dialog>
+    <div class="contact-modal__header">
+      <h2 id="nuevo-contacto-modal-title" class="ent-title">Nuevo contacto</h2>
+      <button type="button" class="contact-modal__close" data-modal-close aria-label="Cerrar">
+        <span class="material-symbols-outlined" aria-hidden="true">close</span>
+      </button>
+    </div>
+    <form method="post" action="/comercial/contactos" class="form ent-form contact-modal__form">
       <div class="form-row">
-        <label for="contacto-entidad">Entidad</label>
-        <select id="contacto-entidad" name="id_entidad" required>
+        <label for="modal-contacto-entidad">Entidad</label>
+        <select id="modal-contacto-entidad" name="id_entidad" required data-focus-initial>
           <?php foreach ($entidades as $ent): ?>
             <option value="<?= h((string)$ent['id']) ?>"><?= h($ent['nombre']) ?></option>
           <?php endforeach; ?>
         </select>
       </div>
       <div class="form-row">
-        <label for="contacto-nombre">Nombre</label>
-        <input id="contacto-nombre" type="text" name="nombre" placeholder="Juan Pérez" required>
+        <label for="modal-contacto-nombre">Nombre</label>
+        <input id="modal-contacto-nombre" type="text" name="nombre" placeholder="Juan Pérez" required>
       </div>
       <div class="form-row">
-        <label for="contacto-titulo">Título</label>
-        <input id="contacto-titulo" type="text" name="titulo" placeholder="Gerente de ventas">
+        <label for="modal-contacto-titulo">Título</label>
+        <input id="modal-contacto-titulo" type="text" name="titulo" placeholder="Gerente de ventas">
       </div>
       <div class="form-row">
-        <label for="contacto-cargo">Cargo</label>
-        <input id="contacto-cargo" type="text" name="cargo" placeholder="Director">
+        <label for="modal-contacto-cargo">Cargo</label>
+        <input id="modal-contacto-cargo" type="text" name="cargo" placeholder="Director">
       </div>
       <div class="form-row">
-        <label for="contacto-telefono">Teléfono</label>
-        <input id="contacto-telefono" type="text" name="telefono" placeholder="+593 9 9999 9999">
+        <label for="modal-contacto-telefono">Teléfono</label>
+        <input id="modal-contacto-telefono" type="text" name="telefono" placeholder="+593 9 9999 9999">
       </div>
       <div class="form-row">
-        <label for="contacto-correo">Correo</label>
-        <input id="contacto-correo" type="email" name="correo" placeholder="correo@dominio.com">
+        <label for="modal-contacto-correo">Correo</label>
+        <input id="modal-contacto-correo" type="email" name="correo" placeholder="correo@dominio.com">
       </div>
       <div class="form-row">
-        <label for="contacto-nota">Nota</label>
-        <textarea id="contacto-nota" name="nota" placeholder="Observaciones adicionales"></textarea>
+        <label for="modal-contacto-nota">Nota</label>
+        <textarea id="modal-contacto-nota" name="nota" placeholder="Observaciones adicionales"></textarea>
       </div>
-      <div class="form-actions ent-actions">
+      <div class="contact-modal__actions">
         <button class="btn btn-primary" type="submit">Crear contacto</button>
+        <button class="btn btn-cancel" type="button" data-modal-cancel>Cancelar</button>
       </div>
     </form>
-  </section>
-
-  <?php if (empty($items)): ?>
-    <div class="card" role="status" aria-live="polite">No se encontraron contactos.</div>
-  <?php else: ?>
-    <ul class="ent-cards-grid" role="list">
-      <?php foreach ($items as $row): ?>
-        <?php
-          $contactId   = (int)($row['id'] ?? 0);
-          $contactName = $row['nombre'] ?? 'Contacto';
-          $entityName  = $row['entidad_nombre'] ?? '';
-          $titulo      = $row['titulo'] ?? '';
-          $cargo       = $row['cargo'] ?? '';
-          $telefono    = $row['telefono'] ?? '';
-          $correo      = $row['correo'] ?? '';
-          $nota        = $row['nota'] ?? '';
-        ?>
-        <li class="ent-cards-grid__item" role="listitem">
-          <article class="ent-card" aria-labelledby="contact-card-title-<?= h((string)$contactId) ?>">
-            <header class="ent-card-head">
-              <div class="ent-card-icon" aria-hidden="true">
-                <span class="material-symbols-outlined" aria-hidden="true">person</span>
-              </div>
-              <h2 id="contact-card-title-<?= h((string)$contactId) ?>" class="ent-card-title">
-                <?= h($contactName) ?>
-              </h2>
-              <span class="ent-badge" aria-label="Entidad asociada">
-                <?= h($entityName) ?>
-              </span>
-            </header>
-            <div class="ent-card-body">
-              <div class="ent-card-row">
-                <span class="ent-card-label">Título</span>
-                <span class="ent-card-value">
-                  <?= $titulo !== '' ? h($titulo) : '—' ?>
-                </span>
-              </div>
-              <div class="ent-card-row">
-                <span class="ent-card-label">Cargo</span>
-                <span class="ent-card-value">
-                  <?= $cargo !== '' ? h($cargo) : '—' ?>
-                </span>
-              </div>
-              <div class="ent-card-row">
-                <span class="ent-card-label">Teléfono</span>
-                <span class="ent-card-value">
-                  <?= $telefono !== '' ? h($telefono) : '—' ?>
-                </span>
-              </div>
-              <div class="ent-card-row">
-                <span class="ent-card-label">Correo</span>
-                <span class="ent-card-value">
-                  <?= $correo !== '' ? h($correo) : '—' ?>
-                </span>
-              </div>
-              <div class="ent-card-row">
-                <span class="ent-card-label">Nota</span>
-                <span class="ent-card-value">
-                  <?= $nota !== '' ? h($nota) : '—' ?>
-                </span>
-              </div>
-            </div>
-            <footer class="ent-card-actions">
-              <form method="post" action="/comercial/contactos/<?= h((string)$contactId) ?>/eliminar" class="ent-card-delete" onsubmit="return confirm('¿Deseas eliminar este contacto?');">
-                <button type="submit" class="btn btn-danger">Eliminar</button>
-              </form>
-            </footer>
-          </article>
-        </li>
-      <?php endforeach; ?>
-    </ul>
-    <nav class="pagination" aria-label="Paginación de contactos">
-      <?php if ($page > 1): ?>
-        <a href="<?= h(buildPageUrlContactos($prev, $filters, $perPage)) ?>" rel="prev">&laquo; Anterior</a>
-      <?php else: ?>
-        <span class="disabled" aria-disabled="true">&laquo; Anterior</span>
-      <?php endif; ?>
-      <span aria-live="polite">Página <?= h((string)(int)$page) ?> de <?= h((string)(int)$pages) ?></span>
-      <?php if ($page < $pages): ?>
-        <a href="<?= h(buildPageUrlContactos($next, $filters, $perPage)) ?>" rel="next">Siguiente &raquo;</a>
-      <?php else: ?>
-        <span class="disabled" aria-disabled="true">Siguiente &raquo;</span>
-      <?php endif; ?>
-    </nav>
-  <?php endif; ?>
-</section>
+  </div>
+</div>
+<div class="contact-modal" id="contacto-editar-modal" data-modal hidden aria-hidden="true">
+  <div class="contact-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="editar-contacto-modal-title" tabindex="-1" data-modal-dialog>
+    <div class="contact-modal__header">
+      <h2 id="editar-contacto-modal-title" class="ent-title">Editar contacto</h2>
+      <button type="button" class="contact-modal__close" data-modal-close aria-label="Cerrar">
+        <span class="material-symbols-outlined" aria-hidden="true">close</span>
+      </button>
+    </div>
+    <form method="post" action="/comercial/contactos" class="form ent-form contact-modal__form" data-contact-edit-form>
+      <div class="form-row">
+        <label for="modal-editar-contacto-entidad">Entidad</label>
+        <select id="modal-editar-contacto-entidad" name="id_entidad" required>
+          <?php foreach ($entidades as $ent): ?>
+            <option value="<?= h((string)$ent['id']) ?>"><?= h($ent['nombre']) ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="form-row">
+        <label for="modal-editar-contacto-nombre">Nombre</label>
+        <input id="modal-editar-contacto-nombre" type="text" name="nombre" required data-focus-initial>
+      </div>
+      <div class="form-row">
+        <label for="modal-editar-contacto-titulo">Título</label>
+        <input id="modal-editar-contacto-titulo" type="text" name="titulo">
+      </div>
+      <div class="form-row">
+        <label for="modal-editar-contacto-cargo">Cargo</label>
+        <input id="modal-editar-contacto-cargo" type="text" name="cargo">
+      </div>
+      <div class="form-row">
+        <label for="modal-editar-contacto-telefono">Teléfono</label>
+        <input id="modal-editar-contacto-telefono" type="text" name="telefono">
+      </div>
+      <div class="form-row">
+        <label for="modal-editar-contacto-correo">Correo</label>
+        <input id="modal-editar-contacto-correo" type="email" name="correo">
+      </div>
+      <div class="form-row">
+        <label for="modal-editar-contacto-nota">Nota</label>
+        <textarea id="modal-editar-contacto-nota" name="nota"></textarea>
+      </div>
+      <div class="contact-modal__actions">
+        <button class="btn btn-primary" type="submit">Guardar cambios</button>
+        <button class="btn btn-cancel" type="button" data-modal-cancel>Cancelar</button>
+      </div>
+    </form>
+  </div>
+</div>
+<script src="/js/contactos-typeahead.js" defer></script>

--- a/app/Views/comercial/dashboard/index.php
+++ b/app/Views/comercial/dashboard/index.php
@@ -1,9 +1,246 @@
-<?php $crumbs = $crumbs ?? []; include __DIR__ . '/../../partials/breadcrumbs.php'; ?>
-<section class="card">
-  <h1>Dashboard Comercial</h1>
-  <div class="cards">
-    <?php foreach ($metrics as $m): ?>
-      <div class="mini-card"><div class="kpi"><?= (int)$m['value'] ?></div><div class="kpi-label"><?= htmlspecialchars($m['label']) ?></div></div>
-    <?php endforeach; ?>
+<?php
+$crumbs = $crumbs ?? array();
+include __DIR__ . '/../../partials/breadcrumbs.php';
+
+$stats = isset($stats) && is_array($stats) ? $stats : array();
+$cards = isset($stats['cards']) && is_array($stats['cards']) ? $stats['cards'] : array();
+$cards = array_merge(array(
+  'total'                => 0,
+  'activas'              => 0,
+  'inactivas'            => 0,
+  'porcentaje_activas'   => 0,
+  'porcentaje_inactivas' => 0,
+  'ultimo_mes'           => 0,
+  'variacion'            => 'Nuevo registro',
+), $cards);
+
+$segmentos = array();
+if (isset($stats['segmentos']) && is_array($stats['segmentos'])) {
+  foreach ($stats['segmentos'] as $row) {
+    if (!is_array($row)) {
+      continue;
+    }
+    $segmentos[] = array(
+      'nombre_segmento' => isset($row['nombre_segmento']) ? (string)$row['nombre_segmento'] : 'Sin segmento',
+      'cantidad'        => isset($row['cantidad']) ? (int)$row['cantidad'] : 0,
+    );
+  }
+}
+
+$estado = array('activas'=>0, 'inactivas'=>0);
+if (isset($stats['estado']) && is_array($stats['estado'])) {
+  $estado['activas']   = isset($stats['estado']['activas']) ? (int)$stats['estado']['activas'] : 0;
+  $estado['inactivas'] = isset($stats['estado']['inactivas']) ? (int)$stats['estado']['inactivas'] : 0;
+}
+
+$mensual = array('labels'=>array(), 'counts'=>array());
+if (isset($stats['mensual']) && is_array($stats['mensual'])) {
+  $mensual['labels'] = isset($stats['mensual']['labels']) && is_array($stats['mensual']['labels']) ? array_values($stats['mensual']['labels']) : array();
+  $mensual['counts'] = isset($stats['mensual']['counts']) && is_array($stats['mensual']['counts']) ? array_map('intval', $stats['mensual']['counts']) : array();
+}
+
+$segmentoLabels = array();
+$segmentoCounts = array();
+foreach ($segmentos as $seg) {
+  $segmentoLabels[] = $seg['nombre_segmento'];
+  $segmentoCounts[] = $seg['cantidad'];
+}
+
+$estadoLabels = array('Activas', 'Inactivas');
+$estadoCounts = array($estado['activas'], $estado['inactivas']);
+
+$errorMsg = isset($error) && $error ? (string)$error : '';
+?>
+<div class="comercial-dashboard">
+  <section class="card comercial-dashboard__header">
+    <div class="comercial-dashboard__title">
+      <h1>Dashboard Comercial</h1>
+      <p class="comercial-dashboard__subtitle">Resumen de cooperativas y actividad reciente.</p>
+    </div>
+  </section>
+
+  <?php if ($errorMsg !== ''): ?>
+    <div class="card comercial-dashboard__alert">
+      <?= htmlspecialchars($errorMsg, ENT_QUOTES, 'UTF-8') ?>
+    </div>
+  <?php endif; ?>
+
+  <div class="comercial-dashboard__stats">
+    <article class="card comercial-dashboard__stat comercial-dashboard__stat--total">
+      <span class="material-symbols-outlined comercial-dashboard__icon">diversity_3</span>
+      <h3>Cooperativas totales</h3>
+      <p class="comercial-dashboard__stat-value"><?= (int)$cards['total'] ?></p>
+      <span class="comercial-dashboard__stat-hint">Registradas</span>
+    </article>
+
+    <article class="card comercial-dashboard__stat comercial-dashboard__stat--activas">
+      <span class="material-symbols-outlined comercial-dashboard__icon">task_alt</span>
+      <h3>Cooperativas activas</h3>
+      <p class="comercial-dashboard__stat-value"><?= (int)$cards['activas'] ?></p>
+      <span class="comercial-dashboard__stat-hint"><?= (int)$cards['porcentaje_activas'] ?>% del total</span>
+    </article>
+
+    <article class="card comercial-dashboard__stat comercial-dashboard__stat--inactivas">
+      <span class="material-symbols-outlined comercial-dashboard__icon">block</span>
+      <h3>Cooperativas inactivas</h3>
+      <p class="comercial-dashboard__stat-value"><?= (int)$cards['inactivas'] ?></p>
+      <span class="comercial-dashboard__stat-hint"><?= (int)$cards['porcentaje_inactivas'] ?>% del total</span>
+    </article>
+
+    <article class="card comercial-dashboard__stat comercial-dashboard__stat--ultimo">
+      <span class="material-symbols-outlined comercial-dashboard__icon">calendar_month</span>
+      <h3>Último mes</h3>
+      <p class="comercial-dashboard__stat-value"><?= (int)$cards['ultimo_mes'] ?></p>
+      <span class="comercial-dashboard__stat-hint"><?= htmlspecialchars((string)$cards['variacion'], ENT_QUOTES, 'UTF-8') ?></span>
+    </article>
   </div>
-</section>
+
+  <section class="card comercial-dashboard__chart comercial-dashboard__chart--full">
+    <header class="comercial-dashboard__chart-header">
+      <h3><span class="material-symbols-outlined">donut_small</span> Distribución por segmento</h3>
+    </header>
+    <div class="comercial-dashboard__canvas">
+      <canvas id="segmentoChart" width="400" height="400"></canvas>
+    </div>
+  </section>
+
+  <div class="comercial-dashboard__charts">
+    <section class="card comercial-dashboard__chart">
+      <header class="comercial-dashboard__chart-header">
+        <h3><span class="material-symbols-outlined">show_chart</span> Registros mensuales</h3>
+      </header>
+      <div class="comercial-dashboard__canvas">
+        <canvas id="mensualChart" width="400" height="320"></canvas>
+      </div>
+    </section>
+
+    <section class="card comercial-dashboard__chart">
+      <header class="comercial-dashboard__chart-header">
+        <h3><span class="material-symbols-outlined">pie_chart</span> Estado de cooperativas</h3>
+      </header>
+      <div class="comercial-dashboard__canvas">
+        <canvas id="estadoChart" width="400" height="320"></canvas>
+      </div>
+    </section>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
+<script>
+(function() {
+  var segmentoLabels = <?= json_encode($segmentoLabels, JSON_UNESCAPED_UNICODE) ?>;
+  var segmentoCounts = <?= json_encode($segmentoCounts, JSON_UNESCAPED_UNICODE) ?>;
+  var estadoLabels   = <?= json_encode($estadoLabels, JSON_UNESCAPED_UNICODE) ?>;
+  var estadoCounts   = <?= json_encode($estadoCounts, JSON_UNESCAPED_UNICODE) ?>;
+  var mensualLabels  = <?= json_encode($mensual['labels'], JSON_UNESCAPED_UNICODE) ?>;
+  var mensualCounts  = <?= json_encode($mensual['counts'], JSON_UNESCAPED_UNICODE) ?>;
+
+  function initCharts() {
+    if (typeof Chart === 'undefined') {
+      return;
+    }
+
+    var chartOptions = {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          position: 'bottom',
+          labels: {
+            padding: 20,
+            usePointStyle: true
+          }
+        },
+        tooltip: {
+          enabled: true,
+          mode: 'index',
+          intersect: false
+        },
+        datalabels: {
+          color: '#fff',
+          font: { weight: 'bold' }
+        }
+      }
+    };
+
+    var segmentoCanvas = document.getElementById('segmentoChart');
+    if (segmentoCanvas) {
+      new Chart(segmentoCanvas, {
+        type: 'doughnut',
+        data: {
+          labels: segmentoLabels,
+          datasets: [{
+            data: segmentoCounts,
+            backgroundColor: ['#212A53', '#FF6600', '#3A4A80', '#FF8533', '#2EC4B6', '#4895EF', '#F72585', '#2D9BF0'],
+            borderWidth: 1
+          }]
+        },
+        options: chartOptions,
+        plugins: typeof ChartDataLabels !== 'undefined' ? [ChartDataLabels] : []
+      });
+    }
+
+    var estadoCanvas = document.getElementById('estadoChart');
+    if (estadoCanvas) {
+      var estadoPlugins = typeof ChartDataLabels !== 'undefined' ? [ChartDataLabels] : [];
+      var estadoOptions = JSON.parse(JSON.stringify(chartOptions));
+      estadoOptions.plugins.datalabels.formatter = function(value, ctx) {
+        var dataset = ctx.chart.data.datasets[0].data || [];
+        var total = dataset.reduce(function(acc, cur) { return acc + cur; }, 0);
+        if (!total) {
+          return '';
+        }
+        var pct = Math.round((value / total) * 100);
+        return pct > 5 ? pct + '%' : '';
+      };
+
+      new Chart(estadoCanvas, {
+        type: 'pie',
+        data: {
+          labels: estadoLabels,
+          datasets: [{
+            data: estadoCounts,
+            backgroundColor: ['#2EC4B6', '#FF6600'],
+            borderWidth: 1
+          }]
+        },
+        options: estadoOptions,
+        plugins: estadoPlugins
+      });
+    }
+
+    var mensualCanvas = document.getElementById('mensualChart');
+    if (mensualCanvas) {
+      var mensualOptions = JSON.parse(JSON.stringify(chartOptions));
+      mensualOptions.plugins.datalabels = false;
+      mensualOptions.interaction = { intersect: false, mode: 'nearest' };
+      mensualOptions.scales = { y: { beginAtZero: true } };
+
+      new Chart(mensualCanvas, {
+        type: 'line',
+        data: {
+          labels: mensualLabels,
+          datasets: [{
+            label: 'Registros',
+            data: mensualCounts,
+            backgroundColor: 'rgba(33, 42, 83, 0.15)',
+            borderColor: '#212A53',
+            borderWidth: 2,
+            tension: 0.4,
+            fill: true,
+            pointBackgroundColor: '#FF6600'
+          }]
+        },
+        options: mensualOptions
+      });
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCharts);
+  } else {
+    initCharts();
+  }
+})();
+</script>

--- a/config/routes.php
+++ b/config/routes.php
@@ -70,9 +70,24 @@ $router->get(
     [ContactosController::class, 'index'],
     ['middleware'=>['auth','role:comercial']]
 );
+$router->get(
+    '/comercial/contactos/sugerencias',
+    [ContactosController::class, 'suggest'],
+    ['middleware'=>['auth','role:comercial']]
+);
 $router->post(
     '/comercial/contactos',
     [ContactosController::class, 'create'],
+    ['middleware'=>['auth','role:comercial']]
+);
+$router->get(
+    '/comercial/contactos/editar',
+    [ContactosController::class, 'editForm'],
+    ['middleware'=>['auth','role:comercial']]
+);
+$router->post(
+    '/comercial/contactos/{id}',
+    [ContactosController::class, 'update'],
     ['middleware'=>['auth','role:comercial']]
 );
 $router->post(

--- a/public/css/comercial_style/comercial-entidades.css
+++ b/public/css/comercial_style/comercial-entidades.css
@@ -144,12 +144,89 @@
 .ent-toolbar{
   display:flex; gap:10px; align-items:center; flex-wrap:wrap; margin: 14px 0;
 }
-.ent-search{
+.ent-search{ 
   display:flex; gap:6px; align-items:center;
+}
+.ent-search--stack{
+  flex-wrap:wrap;
+  align-items:flex-end;
+  gap:10px;
+  margin: 18px 0 24px;
+}
+.ent-search__field{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  gap:.35rem;
+  width:min(420px, 100%);
+  flex:1 1 320px;
+}
+.ent-search--stack label{
+  font-weight:700;
+  color:var(--text-body, #111827);
 }
 .ent-search input[type="text"]{
   width:min(280px, 60vw);
   padding:.55rem .75rem; border:1px solid #d1d5db; border-radius:8px; background:#fff;
+}
+.ent-search__field input[type="text"]{
+  width:100%;
+}
+.ent-search__suggestions{
+  position:absolute;
+  top:100%;
+  left:0;
+  right:0;
+  margin-top:.35rem;
+  background:#fff;
+  border:1px solid #d1d5db;
+  border-radius:10px;
+  box-shadow:0 12px 24px rgba(15,23,42,.12);
+  padding:.35rem 0;
+  z-index:40;
+}
+.ent-search__suggestions[hidden]{
+  display:none;
+}
+.ent-search__suggestion{
+  width:100%;
+  padding:.55rem .85rem;
+  background:transparent;
+  border:0;
+  text-align:left;
+  font-size:.95rem;
+  color:var(--text-body, #111827);
+  cursor:pointer;
+}
+.ent-search__suggestion:hover,
+.ent-search__suggestion.is-active{
+  background:rgba(255,102,0,.12);
+  color:var(--color-secondary, #ff6600);
+}
+.ent-search__actions{
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+  align-items:center;
+  justify-content:flex-start;
+}
+.ent-search__actions .btn{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+.ent-search__new .material-symbols-outlined{
+  font-size:20px;
+  line-height:1;
+}
+.ent-search--with-modal{
+  gap:16px;
+}
+.ent-search--with-modal .ent-search__help{
+  flex-basis:100%;
+}
+.ent-search--with-modal .ent-search__actions{
+  margin-left:auto;
 }
 .ent-search input[type="text"]:focus{
   border-color: var(--color-primary);
@@ -180,6 +257,307 @@
 
 /* Número centrado */
 .ent-table .col-num { text-align:center; color:#6b7280; width: 68px; }
+
+.ent-contactos-list{ margin-top: 32px; }
+
+.contact-list{
+  width:100%;
+  border:1px solid #e5e7eb;
+  border-radius:12px;
+  overflow:hidden;
+  background:#fff;
+  box-shadow:0 1px 3px rgba(15,23,42,.08);
+}
+.contact-list__header,
+.contact-list__row{
+  display:grid;
+  grid-template-columns: minmax(64px, .8fr) minmax(180px, 2fr) minmax(160px, 1.6fr) minmax(140px, 1.4fr) minmax(140px, 1.3fr) minmax(160px, 1.1fr);
+  gap:0;
+  align-items:center;
+}
+.contact-list__header{
+  background: var(--table-header-bg, var(--color-secondary));
+  color: var(--table-header-text, #fff);
+  font-weight:700;
+  font-size:.95rem;
+}
+.contact-list__cell{
+  padding:.75rem .9rem;
+  border-top:1px solid #eef2f6;
+  font-size:.95rem;
+  color: var(--table-row-text, #0f172a);
+}
+.contact-list__header .contact-list__cell{
+  border-top:none;
+}
+.contact-list__row:nth-of-type(odd){
+  background: var(--table-row-bg, #f9fafb);
+}
+.contact-list__row:hover{
+  background: var(--table-row-hover, #FFFAF5);
+}
+.contact-list__cell--actions{
+  display:flex;
+  gap:12px;
+  align-items:center;
+  justify-content:flex-start;
+  flex-wrap:wrap;
+}
+.contact-list__cell--num{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  border-right:1px solid #eef2f6;
+}
+.contact-list__toggle{
+  width:2.25rem;
+  height:2.25rem;
+  border-radius:999px;
+  border:1.5px solid var(--color-secondary);
+  background:#fff;
+  color:var(--color-secondary);
+  font-weight:700;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  transition:all .15s ease;
+}
+.contact-list__toggle:hover,
+.contact-list__toggle[aria-expanded="true"]{
+  background:var(--color-secondary);
+  color:#fff;
+}
+.contact-list__toggle:focus-visible{
+  outline:3px solid rgba(58,74,128,.35);
+  outline-offset:2px;
+}
+.contact-list__details{
+  display:none;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+.contact-list__details[aria-hidden="false"]{
+  display:grid;
+}
+.contact-list__cell--details{
+  grid-column: 1 / -1;
+  border-top:1px solid #e5e7eb;
+  background:#f8fafc;
+}
+.contact-details{
+  display:grid;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+  gap:14px 18px;
+}
+.contact-details__item dt{
+  font-weight:700;
+  font-size:.85rem;
+  color:#4b5563;
+  text-transform:uppercase;
+  letter-spacing:.03em;
+  margin-bottom:4px;
+}
+.contact-details__item dd{
+  margin:0;
+  font-size:.95rem;
+  color:#0f172a;
+  word-break:break-word;
+}
+.contact-details__item--full{
+  grid-column: 1 / -1;
+}
+.contact-details__item--full dd{
+  white-space:pre-wrap;
+}
+.contact-list__cell--header{
+  text-transform:uppercase;
+  letter-spacing:.03em;
+  color:#fff;
+}
+.contact-list__delete{
+  display:inline;
+}
+.contact-list__delete .btn{
+  padding:.55rem .85rem;
+}
+.ent-card-head--compact{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  padding:0;
+  border-bottom:0;
+  margin-bottom:12px;
+}
+.ent-card-toggle{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:38px;
+  height:38px;
+  border-radius:50%;
+  border:1px solid rgba(15,23,42,.15);
+  background:var(--color-secondary);
+  color:#fff;
+  cursor:pointer;
+  transition:background .2s ease, color .2s ease, transform .2s ease;
+}
+.ent-card-toggle:hover,
+.ent-card-toggle:focus-visible{
+  background:var(--color-secondary-dark, #1e3a8a);
+  color:#fff;
+}
+.ent-card-toggle:focus-visible{
+  outline:3px solid rgba(30,64,175,.35);
+  outline-offset:2px;
+}
+.ent-card-toggle .material-symbols-outlined{
+  font-size:22px;
+  line-height:1;
+}
+.contact-modal{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:24px;
+  background:rgba(15,23,42,.55);
+  z-index:200;
+}
+.contact-modal[hidden]{
+  display:none;
+}
+.contact-modal__dialog{
+  background:#fff;
+  border-radius:16px;
+  box-shadow:0 22px 45px rgba(15,23,42,.25);
+  width:min(620px, 100%);
+  max-height:calc(100vh - 60px);
+  overflow-y:auto;
+  padding:26px 30px 30px;
+  position:relative;
+}
+.contact-modal__header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:16px;
+  margin-bottom:18px;
+}
+.contact-modal__close{
+  background:transparent;
+  border:0;
+  width:40px;
+  height:40px;
+  border-radius:50%;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  color:var(--text-body, #0f172a);
+  cursor:pointer;
+  transition:background .2s ease, color .2s ease;
+}
+.contact-modal__close:hover,
+.contact-modal__close:focus-visible{
+  background:rgba(15,23,42,.1);
+  color:var(--color-secondary);
+}
+.contact-modal__close:focus-visible{
+  outline:3px solid rgba(58,74,128,.35);
+  outline-offset:2px;
+}
+.contact-modal__form .form-row{
+  display:flex;
+  flex-direction:column;
+  gap:.45rem;
+  margin-bottom:14px;
+}
+.contact-modal__actions{
+  display:flex;
+  gap:12px;
+  justify-content:flex-end;
+  flex-wrap:wrap;
+  margin-top:24px;
+}
+body.is-modal-open{
+  overflow:hidden;
+}
+@media (max-width: 640px){
+  .contact-modal{
+    padding:16px;
+  }
+  .contact-modal__dialog{
+    padding:20px 18px 24px;
+    border-radius:14px;
+  }
+  .contact-modal__actions{
+    justify-content:stretch;
+  }
+  .contact-modal__actions .btn{
+    flex:1 1 auto;
+    justify-content:center;
+  }
+}
+.u-sr-only{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  border:0;
+}
+@media (max-width: 900px){
+  .contact-list__header,
+  .contact-list__row{
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .contact-list__header{
+    display:none;
+  }
+  .contact-list__row{
+    border-bottom:1px solid #e5e7eb;
+    padding:.45rem 0;
+  }
+  .contact-list__cell{
+    border:none;
+    padding:.55rem .75rem;
+    display:flex;
+    flex-direction:column;
+    gap:4px;
+  }
+  .contact-list__cell--actions{
+    flex-direction:row;
+  }
+  .contact-list__cell--num{
+    justify-content:flex-start;
+    border-right:none;
+  }
+  .contact-list__toggle{
+    width:2rem;
+    height:2rem;
+  }
+  .contact-list__details{
+    grid-template-columns: 1fr;
+  }
+  .contact-list__cell--details{
+    padding:0;
+  }
+  .contact-details{
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    padding:.55rem .75rem .75rem;
+  }
+  .contact-list__cell::before{
+    content: attr(data-label);
+    font-size:.80rem;
+    font-weight:700;
+    color:#6b7280;
+    text-transform:uppercase;
+    letter-spacing:.02em;
+  }
+}
 
 /* Estado como “píldora” */
 .status-pill{
@@ -219,7 +597,61 @@
 .ent-actions{ display:flex; gap:8px; }
 
 /* Paginación (ya tienes estilos globales; sólo centramos) */
-.ent-list .pagination{ justify-content:flex-start; margin-top:12px; }
+.ent-list .pagination{
+  display:flex;
+  align-items:center;
+  justify-content:flex-start;
+  gap:12px;
+  flex-wrap:wrap;
+  margin-top:18px;
+  padding:10px 16px;
+  border-radius:999px;
+  background:#fff;
+  box-shadow:0 12px 24px rgba(15,23,42,.08);
+}
+
+.ent-list .pagination a,
+.ent-list .pagination span{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:.55rem .95rem;
+  border-radius:999px;
+  font-weight:700;
+  font-size:.9rem;
+  transition:background .2s ease, color .2s ease, box-shadow .25s ease, transform .15s ease;
+}
+
+.ent-list .pagination a{
+  background:var(--color-secondary);
+  color:#fff;
+  border:1px solid transparent;
+  text-decoration:none;
+}
+
+.ent-list .pagination a:hover{
+  background:var(--color-secondary-light, #3A4A80);
+  box-shadow:0 10px 18px rgba(58,74,128,.25);
+}
+
+.ent-list .pagination a:active{
+  background:var(--color-secondary-dark, #1A2040);
+  transform:translateY(1px);
+}
+
+.ent-list .pagination .disabled{
+  background:rgba(148,163,184,.22);
+  color:rgba(15,23,42,.55);
+  border:1px dashed rgba(148,163,184,.5);
+  cursor:not-allowed;
+  box-shadow:none;
+}
+
+.ent-list .pagination span[aria-live]{
+  background:rgba(255,102,0,.12);
+  color:var(--color-primary);
+  border:1px solid rgba(255,102,0,.35);
+}
 /* ======= TARJETAS ======= */
 .ent-cards{
   display:grid;
@@ -266,3 +698,162 @@
 }
 .ent-card-actions form{ margin:0; }
 
+
+/* --- Dashboard Comercial --- */
+.comercial-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.comercial-dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(135deg, rgba(33, 42, 83, 0.95), rgba(58, 74, 128, 0.92));
+  color: var(--text-inverse);
+  border: 0;
+  box-shadow: 0 14px 30px rgba(19, 33, 70, 0.22);
+}
+
+.comercial-dashboard__title h1 {
+  margin: 0;
+  color: var(--text-inverse);
+  font-size: 1.9rem;
+}
+
+.comercial-dashboard__subtitle {
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.95rem;
+}
+
+.comercial-dashboard__alert {
+  background: #ffe2e2;
+  border: 1px solid #ffb3b3;
+  color: #8a1c1c;
+  font-weight: 600;
+}
+
+.comercial-dashboard__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.comercial-dashboard__stat {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--text-inverse);
+  min-height: 170px;
+  padding: 22px;
+  border: 0;
+  box-shadow: 0 18px 34px rgba(24, 34, 69, 0.18);
+  overflow: hidden;
+}
+
+.comercial-dashboard__stat h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.comercial-dashboard__stat-value {
+  margin: 4px 0 0;
+  font-size: 2.4rem;
+  font-weight: 700;
+}
+
+.comercial-dashboard__stat-hint {
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.comercial-dashboard__icon {
+  font-size: 36px;
+  align-self: flex-start;
+}
+
+.comercial-dashboard__stat--total {
+  background: linear-gradient(135deg, #212a53, #3a4a80);
+}
+
+.comercial-dashboard__stat--activas {
+  background: linear-gradient(135deg, #2ec4b6, #48dbcb);
+}
+
+.comercial-dashboard__stat--inactivas {
+  background: linear-gradient(135deg, #ff6600, #ff8533);
+}
+
+.comercial-dashboard__stat--ultimo {
+  background: linear-gradient(135deg, #5c2dd5, #7f56d9);
+}
+
+.comercial-dashboard__charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.comercial-dashboard__chart {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+}
+
+.comercial-dashboard__chart--full {
+  padding: 24px;
+}
+
+.comercial-dashboard__chart-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 10px;
+}
+
+.comercial-dashboard__chart-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--color-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.comercial-dashboard__chart-header .material-symbols-outlined {
+  font-size: 22px;
+  color: var(--color-primary);
+}
+
+.comercial-dashboard__canvas {
+  position: relative;
+  width: 100%;
+  min-height: 280px;
+}
+
+.comercial-dashboard__canvas canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+@media (max-width: 768px) {
+  .comercial-dashboard__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .comercial-dashboard__stats {
+    grid-template-columns: 1fr;
+  }
+
+  .comercial-dashboard__charts {
+    grid-template-columns: 1fr;
+  }
+}

--- a/public/js/contactos-typeahead.js
+++ b/public/js/contactos-typeahead.js
@@ -1,0 +1,345 @@
+(function(){
+  const input = document.getElementById('contactos-search-input');
+  const box   = document.getElementById('contactos-search-suggestions');
+  if (!input || !box) { return; }
+
+  const form      = input.form;
+  const minChars  = parseInt(box.getAttribute('data-min-chars') || '3', 10);
+  let controller  = null;
+  let activeIndex = -1;
+  let lastQuery   = '';
+
+  function clearSuggestions() {
+    box.innerHTML = '';
+    box.hidden = true;
+    box.setAttribute('aria-hidden', 'true');
+    input.setAttribute('aria-expanded', 'false');
+    activeIndex = -1;
+  }
+
+  function highlight(index) {
+    const buttons = box.querySelectorAll('button[data-term]');
+    buttons.forEach((btn, idx) => {
+      if (idx === index) {
+        btn.classList.add('is-active');
+        btn.setAttribute('aria-selected', 'true');
+      } else {
+        btn.classList.remove('is-active');
+        btn.setAttribute('aria-selected', 'false');
+      }
+    });
+    activeIndex = index;
+  }
+
+  function selectSuggestion(button) {
+    if (!button) { return; }
+    const term = button.getAttribute('data-term') || '';
+    if (!term) { return; }
+    input.value = term;
+    clearSuggestions();
+    if (form) {
+      form.requestSubmit ? form.requestSubmit() : form.submit();
+    }
+  }
+
+  function renderSuggestions(items) {
+    clearSuggestions();
+    if (!items.length) { return; }
+
+    const frag = document.createDocumentFragment();
+    items.forEach((item, index) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ent-search__suggestion';
+      btn.textContent = item.label || item.term || '';
+      btn.setAttribute('data-term', item.term || '');
+      btn.setAttribute('role', 'option');
+      btn.setAttribute('aria-selected', 'false');
+      btn.addEventListener('mousedown', (ev) => {
+        ev.preventDefault();
+        selectSuggestion(btn);
+      });
+      frag.appendChild(btn);
+    });
+
+    box.appendChild(frag);
+    box.hidden = false;
+    box.setAttribute('aria-hidden', 'false');
+    input.setAttribute('aria-expanded', 'true');
+    highlight(-1);
+  }
+
+  async function fetchSuggestions(query) {
+    if (controller) {
+      controller.abort();
+    }
+    controller = new AbortController();
+
+    try {
+      const response = await fetch('/comercial/contactos/sugerencias?q=' + encodeURIComponent(query), {
+        headers: { 'Accept': 'application/json' },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error('Solicitud fallida');
+      }
+      const data = await response.json();
+      const items = Array.isArray(data.items) ? data.items : [];
+      renderSuggestions(items);
+    } catch (error) {
+      if (error.name === 'AbortError') { return; }
+      clearSuggestions();
+    }
+  }
+
+  input.setAttribute('role', 'combobox');
+  input.setAttribute('aria-autocomplete', 'list');
+  input.setAttribute('aria-expanded', 'false');
+  input.setAttribute('aria-controls', box.id);
+
+  input.addEventListener('input', (event) => {
+    const value = (event.target.value || '').trim();
+    if (value.length < minChars) {
+      clearSuggestions();
+      lastQuery = value;
+      return;
+    }
+    if (value === lastQuery) {
+      return;
+    }
+    lastQuery = value;
+    fetchSuggestions(value);
+  });
+
+  input.addEventListener('keydown', (event) => {
+    if (box.hidden) { return; }
+    const buttons = box.querySelectorAll('button[data-term]');
+    if (!buttons.length) { return; }
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        if (activeIndex < buttons.length - 1) {
+          highlight(activeIndex + 1);
+        } else {
+          highlight(0);
+        }
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (activeIndex > 0) {
+          highlight(activeIndex - 1);
+        } else {
+          highlight(buttons.length - 1);
+        }
+        break;
+      case 'Enter':
+        if (activeIndex >= 0 && buttons[activeIndex]) {
+          event.preventDefault();
+          selectSuggestion(buttons[activeIndex]);
+        }
+        break;
+      case 'Escape':
+        clearSuggestions();
+        break;
+      default:
+        break;
+    }
+  });
+
+  input.addEventListener('blur', () => {
+    setTimeout(() => clearSuggestions(), 120);
+  });
+})();
+
+(function(){
+  const toggles = document.querySelectorAll('[data-contact-toggle]');
+  if (!toggles.length) { return; }
+
+  toggles.forEach((button) => {
+    const targetId = button.getAttribute('aria-controls');
+    const panel = targetId ? document.getElementById(targetId) : null;
+    if (!panel) { return; }
+
+    button.addEventListener('click', () => {
+      const expanded = button.getAttribute('aria-expanded') === 'true';
+      const nextState = !expanded;
+      button.setAttribute('aria-expanded', String(nextState));
+      panel.hidden = !nextState;
+      panel.setAttribute('aria-hidden', String(!nextState));
+    });
+  });
+})();
+
+(function(){
+  const registry = new Map();
+
+  function anyModalVisible() {
+    for (const modal of registry.values()) {
+      if (modal.isVisible()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function setupModal(modalElement) {
+    const dialog = modalElement.querySelector('[data-modal-dialog]');
+    const closeButtons = modalElement.querySelectorAll('[data-modal-close]');
+    const cancelButtons = modalElement.querySelectorAll('[data-modal-cancel]');
+    const form = modalElement.querySelector('form');
+    const focusTarget = modalElement.querySelector('[data-focus-initial]');
+    let lastFocusedElement = null;
+
+    function isVisible() {
+      return modalElement.getAttribute('aria-hidden') === 'false';
+    }
+
+    function show(trigger) {
+      lastFocusedElement = trigger instanceof HTMLElement
+        ? trigger
+        : (document.activeElement instanceof HTMLElement ? document.activeElement : null);
+
+      modalElement.hidden = false;
+      modalElement.setAttribute('aria-hidden', 'false');
+      document.body.classList.add('is-modal-open');
+
+      if (dialog instanceof HTMLElement) {
+        dialog.focus();
+      }
+
+      requestAnimationFrame(() => {
+        if (focusTarget instanceof HTMLElement) {
+          focusTarget.focus();
+        }
+      });
+    }
+
+    function hide() {
+      modalElement.hidden = true;
+      modalElement.setAttribute('aria-hidden', 'true');
+
+      if (form instanceof HTMLFormElement && modalElement.getAttribute('data-modal-reset') !== 'false') {
+        form.reset();
+      }
+
+      if (!anyModalVisible()) {
+        document.body.classList.remove('is-modal-open');
+      }
+
+      if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+        lastFocusedElement.focus();
+      }
+    }
+
+    closeButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        if (isVisible()) {
+          hide();
+        }
+      });
+    });
+
+    cancelButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        if (isVisible()) {
+          hide();
+        }
+      });
+    });
+
+    modalElement.addEventListener('click', (event) => {
+      if (event.target === modalElement && isVisible()) {
+        hide();
+      }
+    });
+
+    return {
+      show,
+      hide,
+      isVisible,
+    };
+  }
+
+  document.querySelectorAll('[data-modal]').forEach((modalElement) => {
+    const instance = setupModal(modalElement);
+    const key = modalElement.id || modalElement.getAttribute('data-modal-id');
+    if (!key) { return; }
+    registry.set(key, instance);
+  });
+
+  document.querySelectorAll('[data-modal-open]').forEach((button) => {
+    const targetId = button.getAttribute('data-modal-open');
+    if (!targetId) { return; }
+    const modal = registry.get(targetId);
+    if (!modal) { return; }
+
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      modal.show(button);
+    });
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      let handled = false;
+      registry.forEach((modal) => {
+        if (modal.isVisible()) {
+          modal.hide();
+          handled = true;
+        }
+      });
+      if (handled) {
+        event.preventDefault();
+      }
+    }
+  });
+
+  window.contactModals = {
+    get(id) {
+      return registry.get(id) || null;
+    },
+  };
+})();
+
+(function(){
+  const editModalId = 'contacto-editar-modal';
+  const modal = document.getElementById(editModalId);
+  if (!modal) { return; }
+
+  const form = modal.querySelector('[data-contact-edit-form]');
+  const entidad = modal.querySelector('#modal-editar-contacto-entidad');
+  const nombre = modal.querySelector('#modal-editar-contacto-nombre');
+  const titulo = modal.querySelector('#modal-editar-contacto-titulo');
+  const cargo = modal.querySelector('#modal-editar-contacto-cargo');
+  const telefono = modal.querySelector('#modal-editar-contacto-telefono');
+  const correo = modal.querySelector('#modal-editar-contacto-correo');
+  const nota = modal.querySelector('#modal-editar-contacto-nota');
+
+  function setValue(field, value) {
+    if (field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement || field instanceof HTMLSelectElement) {
+      field.value = value || '';
+    }
+  }
+
+  document.querySelectorAll('[data-contact-edit]').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      if (!(form instanceof HTMLFormElement)) { return; }
+
+      const contactId = button.getAttribute('data-contact-id') || '';
+      if (contactId === '') { return; }
+
+      form.setAttribute('action', '/comercial/contactos/' + encodeURIComponent(contactId));
+      setValue(entidad, button.getAttribute('data-contact-entidad') || '');
+      setValue(nombre, button.getAttribute('data-contact-nombre') || '');
+      setValue(titulo, button.getAttribute('data-contact-titulo') || '');
+      setValue(cargo, button.getAttribute('data-contact-cargo') || '');
+      setValue(telefono, button.getAttribute('data-contact-telefono') || '');
+      setValue(correo, button.getAttribute('data-contact-correo') || '');
+      setValue(nota, button.getAttribute('data-contact-nota') || '');
+
+    }, { capture: true });
+  });
+})();


### PR DESCRIPTION
## Summary
- add a commercial dashboard repository and service to compute cooperativa totals, segment mix, and recent monthly registrations
- update the dashboard controller and view to render KPI cards plus Chart.js visualisations with graceful error handling
- extend the commercial stylesheet with dashboard-specific layouts and color treatments for the new widgets

## Testing
- php -l app/Repositories/Comercial/DashboardRepository.php
- php -l app/Services/Comercial/DashboardService.php
- php -l app/Controllers/Comercial/DashboardController.php
- php -l app/Views/comercial/dashboard/index.php

------
https://chatgpt.com/codex/tasks/task_e_68dee32de4d8832688c79585a66ed42f