### PR TITLE
Enhance login screen and seguimiento workflows

### DIFF
--- a/app/Controllers/Comercial/ContactosController.php
+++ b/app/Controllers/Comercial/ContactosController.php
@@ -123,9 +123,17 @@ final class ContactosController
             return;
         }
 
+        $idEntidad = (int)($_POST['id_entidad'] ?? 0);
+        $nombre    = trim((string)($_POST['nombre'] ?? ''));
+
+        if ($idEntidad < 1 || $nombre === '') {
+            redirect('/comercial/contactos');
+            return;
+        }
+
         $data = [
-            'id_cooperativa'    => (int)($_POST['id_entidad'] ?? 0),
-            'nombre'            => trim((string)($_POST['nombre'] ?? '')),
+            'id_cooperativa'    => $idEntidad,
+            'nombre'            => $nombre,
             'titulo'            => trim((string)($_POST['titulo'] ?? '')),
             'cargo'             => trim((string)($_POST['cargo'] ?? '')),
             'telefono_contacto' => $telefono,
@@ -140,9 +148,9 @@ final class ContactosController
     /**
      * Muestra el formulario para editar un contacto existente.
      */
-    public function editForm()
+    public function editForm($id)
     {
-        $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+        $id = (int)$id;
         if ($id < 1) {
             redirect('/comercial/contactos');
             return;
@@ -181,15 +189,29 @@ final class ContactosController
             return;
         }
 
+        $postedId = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+        if ($postedId > 0 && $postedId !== $id) {
+            redirect('/comercial/contactos');
+            return;
+        }
+
         $correo = trim((string)($_POST['correo'] ?? ''));
         if ($correo !== '' && !\filter_var($correo, FILTER_VALIDATE_EMAIL)) {
             redirect('/comercial/contactos');
             return;
         }
 
+        $idEntidad = (int)($_POST['id_entidad'] ?? 0);
+        $nombre    = trim((string)($_POST['nombre'] ?? ''));
+
+        if ($idEntidad < 1 || $nombre === '') {
+            redirect('/comercial/contactos');
+            return;
+        }
+
         $data = [
-            'id_cooperativa'    => (int)($_POST['id_entidad'] ?? 0),
-            'nombre'            => trim((string)($_POST['nombre'] ?? '')),
+            'id_cooperativa'    => $idEntidad,
+            'nombre'            => $nombre,
             'titulo'            => trim((string)($_POST['titulo'] ?? '')),
             'cargo'             => trim((string)($_POST['cargo'] ?? '')),
             'telefono_contacto' => $telefono,

--- a/app/Controllers/Comercial/SeguimientoController.php
+++ b/app/Controllers/Comercial/SeguimientoController.php
@@ -2,9 +2,11 @@
 namespace App\Controllers\Comercial;
 
 use App\Repositories\Comercial\SeguimientoRepository;
+use App\Services\Shared\Breadcrumbs;
 use App\Services\Shared\Pagination;
-use function \redirect;
-use function \view;
+use RuntimeException;
+use function redirect;
+use function view;
 
 final class SeguimientoController
 {
@@ -19,11 +21,6 @@ final class SeguimientoController
     public function index(): void
     {
         $filters = is_array($_GET) ? $_GET : [];
-        $fechaFiltro = isset($filters['fecha']) ? trim((string)$filters['fecha']) : '';
-        if ($fechaFiltro === '') {
-            $filters['fecha'] = date('Y-m-d');
-        }
-
         $pager = Pagination::fromRequest($filters, 1, 10, 0);
         $result = $this->repo->paginate($filters, $pager->page, $pager->perPage);
 
@@ -40,43 +37,66 @@ final class SeguimientoController
         ]);
     }
 
+    public function createForm(): void
+    {
+        $crumbs = Breadcrumbs::make([
+            ['href' => '/comercial', 'label' => 'Comercial'],
+            ['href' => '/comercial/eventos', 'label' => 'Seguimiento diario'],
+            ['label' => 'Nuevo seguimiento'],
+        ]);
+
+        view('comercial/seguimiento/create', [
+            'layout'       => 'layout',
+            'title'        => 'Nuevo seguimiento',
+            'crumbs'       => $crumbs,
+            'cooperativas' => $this->repo->listadoCooperativas(),
+            'tipos'        => $this->repo->catalogoTipos(),
+        ]);
+    }
+
     public function store(): void
     {
-        $fecha = isset($_POST['fecha']) ? trim((string)$_POST['fecha']) : '';
-        if ($fecha === '') {
-            $fecha = date('Y-m-d');
-        }
-
-        $data = [
-            'id_cooperativa' => (int)($_POST['id_cooperativa'] ?? 0),
-            'fecha'          => $fecha,
-            'tipo'           => trim((string)($_POST['tipo'] ?? '')),
-            'descripcion'    => trim((string)($_POST['descripcion'] ?? '')),
-            'ticket'         => trim((string)($_POST['ticket'] ?? '')),
-            'creado_por'     => $this->currentUserId(),
-        ];
-
-        if ($data['tipo'] === '') {
-            $data['tipo'] = 'Seguimiento';
-        }
-
-        if ($data['id_cooperativa'] < 1 || $data['descripcion'] === '') {
-            redirect('/comercial/eventos');
+        $parsed = $this->parseSeguimientoInput($_POST, false);
+        if ($parsed['errors']) {
+            redirect('/comercial/eventos/crear?error=validacion');
             return;
         }
 
+        $data = $parsed['data'];
+        $data['creado_por'] = $this->currentUserId();
         $this->repo->create($data);
+
         redirect('/comercial/eventos');
+    }
+
+    public function update(int $id): void
+    {
+        header('Content-Type: application/json; charset=UTF-8');
+
+        $parsed = $this->parseSeguimientoInput($_POST, true);
+        if ($parsed['errors']) {
+            http_response_code(422);
+            echo json_encode([
+                'ok'     => false,
+                'errors' => $parsed['errors'],
+            ], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        $data = $parsed['data'];
+        $data['usuario_editor'] = $this->currentUserId();
+        $this->repo->update($id, $data);
+
+        $fresh = $this->repo->find($id);
+        echo json_encode([
+            'ok'   => true,
+            'item' => $fresh,
+        ], JSON_UNESCAPED_UNICODE);
     }
 
     public function export(): void
     {
         $filters = is_array($_GET) ? $_GET : [];
-        $fechaFiltro = isset($filters['fecha']) ? trim((string)$filters['fecha']) : '';
-        if ($fechaFiltro === '') {
-            $filters['fecha'] = date('Y-m-d');
-        }
-
         $rows = $this->repo->listarParaExportar($filters);
 
         header('Content-Type: application/vnd.ms-excel; charset=UTF-8');
@@ -91,22 +111,200 @@ final class SeguimientoController
             return;
         }
 
-        fputcsv($out, ['Fecha', 'Cooperativa', 'Tipo', 'Descripción', 'Ticket', 'Registrado por'], ';');
+        fputcsv($out, ['Fecha inicio', 'Fecha fin', 'Entidad', 'Tipo', 'Descripción', 'Ticket', 'Registrado por'], ';');
         foreach ($rows as $row) {
             $descripcion = isset($row['descripcion']) ? preg_replace('/\s+/u', ' ', (string)$row['descripcion']) : '';
-            $usuario = isset($row['usuario']) ? (string)$row['usuario'] : '';
             fputcsv($out, [
-                isset($row['fecha']) ? (string)$row['fecha'] : '',
+                isset($row['fecha_inicio']) ? (string)$row['fecha_inicio'] : '',
+                isset($row['fecha_fin']) ? (string)$row['fecha_fin'] : '',
                 isset($row['cooperativa']) ? (string)$row['cooperativa'] : '',
                 isset($row['tipo']) ? (string)$row['tipo'] : '',
                 $descripcion,
-                isset($row['ticket']) ? (string)$row['ticket'] : '',
-                $usuario,
+                isset($row['ticket_codigo']) ? (string)$row['ticket_codigo'] : '',
+                isset($row['usuario']) ? (string)$row['usuario'] : '',
             ], ';');
         }
 
         fclose($out);
         exit;
+    }
+
+    public function contactos(): void
+    {
+        header('Content-Type: application/json; charset=UTF-8');
+        $entidadId = isset($_GET['entidad']) ? (int)$_GET['entidad'] : 0;
+        if ($entidadId <= 0) {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'errors' => ['Seleccione una entidad válida.']], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        $items = $this->repo->contactosPorEntidad($entidadId);
+        echo json_encode(['ok' => true, 'items' => $items], JSON_UNESCAPED_UNICODE);
+    }
+
+    public function ticketSearch(): void
+    {
+        header('Content-Type: application/json; charset=UTF-8');
+        $term = isset($_GET['q']) ? trim((string)$_GET['q']) : '';
+        if ($term === '') {
+            echo json_encode(['ok' => true, 'items' => []], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        $items = $this->repo->buscarTickets($term);
+        echo json_encode(['ok' => true, 'items' => $items], JSON_UNESCAPED_UNICODE);
+    }
+
+    public function ticketFilterSearch(): void
+    {
+        header('Content-Type: application/json; charset=UTF-8');
+        $term = isset($_GET['q']) ? trim((string)$_GET['q']) : '';
+        if ($term === '') {
+            echo json_encode(['ok' => true, 'items' => []], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        $items = $this->repo->buscarTicketsSeguimiento($term);
+        echo json_encode(['ok' => true, 'items' => $items], JSON_UNESCAPED_UNICODE);
+    }
+
+    public function ticketInfo(int $id): void
+    {
+        header('Content-Type: application/json; charset=UTF-8');
+        $ticket = $this->repo->ticketPorId($id);
+        if ($ticket === null) {
+            http_response_code(404);
+            echo json_encode(['ok' => false, 'errors' => ['Ticket no encontrado.']], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        echo json_encode(['ok' => true, 'item' => $ticket], JSON_UNESCAPED_UNICODE);
+    }
+
+    public function delete(int $id): void
+    {
+        header('Content-Type: application/json; charset=UTF-8');
+        if ($id <= 0) {
+            http_response_code(400);
+            echo json_encode(['ok' => false, 'errors' => ['Seguimiento inválido.']], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        try {
+            $this->repo->delete($id);
+        } catch (RuntimeException $e) {
+            http_response_code(500);
+            echo json_encode(['ok' => false, 'errors' => [$e->getMessage()]], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        echo json_encode(['ok' => true], JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * @param array<string,mixed> $source
+     * @return array{data:array<string,mixed>,errors:array<int,string>}
+     */
+    private function parseSeguimientoInput(array $source, bool $forUpdate): array
+    {
+        $data = [
+            'id_cooperativa' => (int)($source['id_cooperativa'] ?? 0),
+            'fecha_inicio'   => trim((string)($source['fecha_inicio'] ?? '')),
+            'fecha_fin'      => trim((string)($source['fecha_fin'] ?? '')),
+            'tipo'           => trim((string)($source['tipo'] ?? '')),
+            'descripcion'    => trim((string)($source['descripcion'] ?? '')),
+            'id_contacto'    => isset($source['id_contacto']) && $source['id_contacto'] !== ''
+                ? (int)$source['id_contacto']
+                : null,
+            'ticket_id'      => isset($source['ticket_id']) && $source['ticket_id'] !== ''
+                ? (int)$source['ticket_id']
+                : null,
+            'datos_ticket'   => isset($source['ticket_datos']) ? trim((string)$source['ticket_datos']) : '',
+            'datos_reunion'  => null,
+        ];
+
+        if ($data['fecha_fin'] === '') {
+            $data['fecha_fin'] = null;
+        }
+
+        $errors = [];
+        if ($data['id_cooperativa'] <= 0) {
+            $errors[] = 'Debe seleccionar una entidad válida.';
+        }
+        if ($data['fecha_inicio'] === '') {
+            $errors[] = 'Debe indicar la fecha de inicio.';
+        }
+        if ($data['tipo'] === '') {
+            $errors[] = 'Debe seleccionar el tipo de gestión.';
+        }
+        if ($data['descripcion'] === '') {
+            $errors[] = 'La descripción es obligatoria.';
+        }
+
+        if ($data['fecha_inicio'] !== null && $data['fecha_fin'] !== null && $data['fecha_fin'] !== '') {
+            if (strtotime($data['fecha_fin']) !== false && strtotime($data['fecha_inicio']) !== false) {
+                if (strtotime($data['fecha_fin']) < strtotime($data['fecha_inicio'])) {
+                    $errors[] = 'La fecha de finalización no puede ser anterior a la fecha de inicio.';
+                }
+            }
+        }
+
+        $ticketData = null;
+        if ($data['datos_ticket'] !== '') {
+            $decoded = json_decode($data['datos_ticket'], true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $ticketData = $decoded;
+            } else {
+                $errors[] = 'El detalle del ticket es inválido.';
+            }
+        }
+
+        $tipo = $data['tipo'];
+        switch (mb_strtolower($tipo)) {
+            case 'contacto':
+                if ($data['id_contacto'] === null || $data['id_contacto'] <= 0) {
+                    $errors[] = 'Debe seleccionar un contacto relacionado.';
+                }
+                $data['ticket_id'] = null;
+                $ticketData = null;
+                break;
+            case 'ticket':
+                if ($data['ticket_id'] === null || $data['ticket_id'] <= 0) {
+                    $errors[] = 'Debe seleccionar un ticket.';
+                }
+                if ($ticketData === null && $data['ticket_id']) {
+                    try {
+                        $ticket = $this->repo->ticketPorId($data['ticket_id']);
+                    } catch (RuntimeException $e) {
+                        $ticket = null;
+                    }
+                    if ($ticket) {
+                        $ticketData = [
+                            'codigo'       => $ticket['codigo'] ?? '',
+                            'departamento' => $ticket['departamento'] ?? '',
+                            'tipo'         => $ticket['tipo'] ?? '',
+                            'prioridad'    => $ticket['prioridad'] ?? '',
+                            'estado'       => $ticket['estado'] ?? '',
+                        ];
+                    }
+                }
+                $data['id_contacto'] = null;
+                break;
+            default:
+                $data['id_contacto'] = null;
+                $data['ticket_id'] = null;
+                $ticketData = null;
+        }
+
+        $data['datos_ticket'] = $ticketData !== null
+            ? json_encode($ticketData, JSON_UNESCAPED_UNICODE)
+            : null;
+
+        return [
+            'data'   => $data,
+            'errors' => $errors,
+        ];
     }
 
     private function currentUserId(): ?int

--- a/app/Repositories/Comercial/IncidenciaRepository.php
+++ b/app/Repositories/Comercial/IncidenciaRepository.php
@@ -18,7 +18,6 @@ final class IncidenciaRepository extends BaseRepository
     private const COL_DESCRIP  = 'descripcion';
     private const COL_PRIOR    = 'prioridad';
     private const COL_ESTADO   = 'estado';
-    private const COL_TIPO_NAME = 'tipo_incidencia';
     private const COL_TIPO_ID   = 'tipo_incidencia_id';
     private const COL_TIPO_DEP  = 'tipo_incidencia_departamento_id';
     private const COL_TICKET   = 'id_ticket';
@@ -53,8 +52,6 @@ final class IncidenciaRepository extends BaseRepository
     private $incidenciaColumns = null;
     /** @var array<int,array{id:int,departamento_id:int,nombre:string,global_id:?int}> */
     private $tipoDepartamentoCache = [];
-    /** @var array<string,int>|null */
-    private $globalTipoMap = null;
 
     /**
      * Obtiene un listado paginado de incidencias según filtros.
@@ -261,62 +258,27 @@ final class IncidenciaRepository extends BaseRepository
     /**
      * Determina las expresiones y joins necesarios para obtener el tipo de incidencia.
      *
-     * @return array{select_nombre:string,select_id:string,joins:array<int,string>}
+     * @return array{select_nombre:string,select_id:string,select_global:string,joins:array<int,string>}
      */
     private function tipoSelectFragments(): array
     {
-        $hasNombre = $this->incidenciaHasColumn(self::COL_TIPO_NAME);
         $hasTipoDepto = $this->incidenciaHasColumn(self::COL_TIPO_DEP);
         $hasTipoId = $this->incidenciaHasColumn(self::COL_TIPO_ID);
 
-        $selectNombre = "'' AS tipo_incidencia";
-        $selectId = 'NULL AS tipo_departamento_id';
-        $selectGlobal = 'NULL AS tipo_global_id';
+        $selectId = 'i.' . self::COL_TIPO_ID . ' AS tipo_departamento_id';
+        $selectNombre = "COALESCE(tipo_dep." . self::TIPO_NOMBRE . ", 'Sin tipo') AS tipo_incidencia";
+        $selectGlobal = 'tipo_dep.' . self::TIPO_REF . ' AS tipo_global_id';
         $joins = [];
 
         if ($hasTipoDepto) {
             $selectId = 'i.' . self::COL_TIPO_DEP . ' AS tipo_departamento_id';
             $joins[] = 'LEFT JOIN ' . self::T_TIPOS_DEP . ' tipo_dep ON tipo_dep.' . self::TIPO_ID . ' = i.' . self::COL_TIPO_DEP;
-            $joins[] = 'LEFT JOIN ' . self::T_TIPOS_GLOBAL . ' tipo_global ON tipo_global.' . self::TIPO_GLOBAL_ID . ' = tipo_dep.' . self::TIPO_REF;
-
-            $nombreExprParts = [];
-            $nombreExprParts[] = 'tipo_dep.' . self::TIPO_NOMBRE;
-            $nombreExprParts[] = 'tipo_global.' . self::TIPO_GLOBAL_NOMBRE;
-            if ($hasNombre) {
-                $nombreExprParts[] = 'i.' . self::COL_TIPO_NAME;
-            }
-            $selectNombre = 'COALESCE(' . implode(', ', $nombreExprParts) . ') AS tipo_incidencia';
-
-            $globalParts = [];
-            if ($hasTipoId) {
-                $globalParts[] = 'i.' . self::COL_TIPO_ID;
-            }
-            $globalParts[] = 'tipo_dep.' . self::TIPO_REF;
-            $globalParts[] = 'tipo_global.' . self::TIPO_GLOBAL_ID;
-            $globalParts = array_filter($globalParts);
-            if (!empty($globalParts)) {
-                $selectGlobal = 'COALESCE(' . implode(', ', $globalParts) . ') AS tipo_global_id';
-            }
         } elseif ($hasTipoId) {
-            $selectId = 'i.' . self::COL_TIPO_ID . ' AS tipo_departamento_id';
             $joins[] = 'LEFT JOIN ' . self::T_TIPOS_DEP . ' tipo_dep ON tipo_dep.' . self::TIPO_ID . ' = i.' . self::COL_TIPO_ID;
-            $joins[] = 'LEFT JOIN ' . self::T_TIPOS_GLOBAL . ' tipo_global ON tipo_global.' . self::TIPO_GLOBAL_ID . ' = i.' . self::COL_TIPO_ID;
-
-            $nombreExprParts = [];
-            $nombreExprParts[] = 'tipo_dep.' . self::TIPO_NOMBRE;
-            $nombreExprParts[] = 'tipo_global.' . self::TIPO_GLOBAL_NOMBRE;
-            if ($hasNombre) {
-                $nombreExprParts[] = 'i.' . self::COL_TIPO_NAME;
-            }
-            $selectNombre = 'COALESCE(' . implode(', ', $nombreExprParts) . ') AS tipo_incidencia';
-
-            $globalParts = ['i.' . self::COL_TIPO_ID, 'tipo_global.' . self::TIPO_GLOBAL_ID];
-            $globalParts = array_filter($globalParts);
-            if (!empty($globalParts)) {
-                $selectGlobal = 'COALESCE(' . implode(', ', $globalParts) . ') AS tipo_global_id';
-            }
-        } elseif ($hasNombre) {
-            $selectNombre = 'i.' . self::COL_TIPO_NAME . ' AS tipo_incidencia';
+        } else {
+            $selectNombre = "'Sin tipo' AS tipo_incidencia";
+            $selectId = 'NULL AS tipo_departamento_id';
+            $selectGlobal = 'NULL AS tipo_global_id';
         }
 
         return [
@@ -324,6 +286,63 @@ final class IncidenciaRepository extends BaseRepository
             'select_id'     => $selectId,
             'select_global' => $selectGlobal,
             'joins'         => $joins,
+        ];
+    }
+
+    /**
+     * Determina los identificadores de tipo a persistir según el esquema disponible.
+     *
+     * @return array{departamental:?int,global:?int}
+     */
+    private function resolveTipoBindings(int $tipoSolicitadoId, int $departamentoId): array
+    {
+        $hasTipoDepto = $this->incidenciaHasColumn(self::COL_TIPO_DEP);
+        $hasTipoGlobal = $this->incidenciaHasColumn(self::COL_TIPO_ID);
+
+        $departamentalId = null;
+        $globalId = null;
+        $tipoSeleccionado = null;
+
+        if ($tipoSolicitadoId > 0) {
+            $tipoSeleccionado = $this->findTipoPorId($tipoSolicitadoId);
+            if ($tipoSeleccionado !== null) {
+                $departamentalId = (int)$tipoSeleccionado['id'];
+                if (!empty($tipoSeleccionado['global_id'])) {
+                    $globalId = (int)$tipoSeleccionado['global_id'];
+                }
+            } elseif ($hasTipoGlobal) {
+                $globalId = $this->ensureTipoGlobalId($tipoSolicitadoId);
+            }
+        }
+
+        if ($hasTipoDepto && $departamentalId === null) {
+            $departamentalId = $this->resolveTipoDepartamentoId(0, $departamentoId);
+            $tipoSeleccionado = $this->findTipoPorId($departamentalId);
+            if ($tipoSeleccionado !== null && $globalId === null && !empty($tipoSeleccionado['global_id'])) {
+                $globalId = (int)$tipoSeleccionado['global_id'];
+            }
+        }
+
+        if ($hasTipoGlobal) {
+            if ($globalId === null && $departamentalId !== null) {
+                $tipoSeleccionado = $tipoSeleccionado ?? $this->findTipoPorId($departamentalId);
+                if ($tipoSeleccionado !== null && !empty($tipoSeleccionado['global_id'])) {
+                    $globalId = (int)$tipoSeleccionado['global_id'];
+                }
+            }
+
+            if ($globalId === null) {
+                $globalId = $this->findPrimerTipoGlobalId();
+            }
+        }
+
+        if (!$hasTipoDepto) {
+            $departamentalId = null;
+        }
+
+        return [
+            'departamental' => $departamentalId,
+            'global'        => $globalId,
         ];
     }
 
@@ -344,15 +363,19 @@ final class IncidenciaRepository extends BaseRepository
             ? [$departamentoId, PDO::PARAM_INT]
             : [null, PDO::PARAM_NULL];
 
-        $tipoDepartamentoId = isset($data['tipo_incidencia_id']) ? (int)$data['tipo_incidencia_id'] : 0;
-        $tipoDepartamentoParam = $tipoDepartamentoId > 0
+        $hasTipoDepto  = $this->incidenciaHasColumn(self::COL_TIPO_DEP);
+        $hasTipoId     = $this->incidenciaHasColumn(self::COL_TIPO_ID);
+
+        $tipoSolicitadoId = isset($data['tipo_incidencia_id']) ? (int)$data['tipo_incidencia_id'] : 0;
+        $tipoBindings = $this->resolveTipoBindings($tipoSolicitadoId, $departamentoId);
+
+        $tipoDepartamentoId = $tipoBindings['departamental'];
+        $tipoDepartamentoParam = $tipoDepartamentoId !== null
             ? [$tipoDepartamentoId, PDO::PARAM_INT]
             : [null, PDO::PARAM_NULL];
 
-        $providedGlobalId = isset($data['tipo_incidencia_global_id']) ? (int)$data['tipo_incidencia_global_id'] : 0;
-        $tipoNombre = isset($data['tipo_incidencia']) ? (string)$data['tipo_incidencia'] : '';
-        $tipoGlobalId = $this->resolveTipoGlobalIdFor($tipoDepartamentoId, $providedGlobalId, $tipoNombre);
-        $tipoGlobalParam = $tipoGlobalId !== null && $tipoGlobalId > 0
+        $tipoGlobalId = $tipoBindings['global'];
+        $tipoGlobalParam = $tipoGlobalId !== null
             ? [$tipoGlobalId, PDO::PARAM_INT]
             : [null, PDO::PARAM_NULL];
 
@@ -372,26 +395,16 @@ final class IncidenciaRepository extends BaseRepository
         $values[]  = ':asunto';
         $params[':asunto'] = [$data['asunto'] ?? '', PDO::PARAM_STR];
 
-        $hasTipoNombre = $this->incidenciaHasColumn(self::COL_TIPO_NAME);
-        $hasTipoDepto  = $this->incidenciaHasColumn(self::COL_TIPO_DEP);
-        $hasTipoId     = $this->incidenciaHasColumn(self::COL_TIPO_ID);
-
-        if ($hasTipoDepto) {
-            $columns[] = self::COL_TIPO_DEP;
-            $values[]  = ':tipo_departamento';
-            $params[':tipo_departamento'] = $tipoDepartamentoParam;
-        }
-
         if ($hasTipoId) {
             $columns[] = self::COL_TIPO_ID;
             $values[]  = ':tipo_global';
             $params[':tipo_global'] = $tipoGlobalParam;
         }
 
-        if ($hasTipoNombre) {
-            $columns[] = self::COL_TIPO_NAME;
-            $values[]  = ':tipo_nombre';
-            $params[':tipo_nombre'] = [$data['tipo_incidencia'] ?? '', PDO::PARAM_STR];
+        if ($hasTipoDepto) {
+            $columns[] = self::COL_TIPO_DEP;
+            $values[]  = ':tipo_departamental';
+            $params[':tipo_departamental'] = $tipoDepartamentoParam;
         }
 
         $columns[] = self::COL_DESCRIP;
@@ -446,15 +459,19 @@ final class IncidenciaRepository extends BaseRepository
             ? [$departamentoId, PDO::PARAM_INT]
             : [null, PDO::PARAM_NULL];
 
-        $tipoDepartamentoId = isset($data['tipo_incidencia_id']) ? (int)$data['tipo_incidencia_id'] : 0;
-        $tipoDepartamentoParam = $tipoDepartamentoId > 0
+        $hasTipoDepto  = $this->incidenciaHasColumn(self::COL_TIPO_DEP);
+        $hasTipoId     = $this->incidenciaHasColumn(self::COL_TIPO_ID);
+
+        $tipoSolicitadoId = isset($data['tipo_incidencia_id']) ? (int)$data['tipo_incidencia_id'] : 0;
+        $tipoBindings = $this->resolveTipoBindings($tipoSolicitadoId, $departamentoId);
+
+        $tipoDepartamentoId = $tipoBindings['departamental'];
+        $tipoDepartamentoParam = $tipoDepartamentoId !== null
             ? [$tipoDepartamentoId, PDO::PARAM_INT]
             : [null, PDO::PARAM_NULL];
 
-        $providedGlobalId = isset($data['tipo_incidencia_global_id']) ? (int)$data['tipo_incidencia_global_id'] : 0;
-        $tipoNombre = isset($data['tipo_incidencia']) ? (string)$data['tipo_incidencia'] : '';
-        $tipoGlobalId = $this->resolveTipoGlobalIdFor($tipoDepartamentoId, $providedGlobalId, $tipoNombre);
-        $tipoGlobalParam = $tipoGlobalId !== null && $tipoGlobalId > 0
+        $tipoGlobalId = $tipoBindings['global'];
+        $tipoGlobalParam = $tipoGlobalId !== null
             ? [$tipoGlobalId, PDO::PARAM_INT]
             : [null, PDO::PARAM_NULL];
 
@@ -474,28 +491,19 @@ final class IncidenciaRepository extends BaseRepository
             ':descripcion' => $descripcionParam,
         ];
 
-        $hasTipoNombre = $this->incidenciaHasColumn(self::COL_TIPO_NAME);
-        $hasTipoDepto  = $this->incidenciaHasColumn(self::COL_TIPO_DEP);
-        $hasTipoId     = $this->incidenciaHasColumn(self::COL_TIPO_ID);
-
-        if ($hasTipoNombre) {
-            $sets[] = self::COL_TIPO_NAME . ' = :tipo_nombre';
-            $params[':tipo_nombre'] = [$data['tipo_incidencia'] ?? '', PDO::PARAM_STR];
-        }
-
         if ($this->incidenciaHasColumn(self::COL_DEPTO)) {
             $sets[] = self::COL_DEPTO . ' = :departamento';
             $params[':departamento'] = $departamentoParam;
         }
 
-        if ($hasTipoDepto) {
-            $sets[] = self::COL_TIPO_DEP . ' = :tipo_departamento';
-            $params[':tipo_departamento'] = $tipoDepartamentoParam;
-        }
-
         if ($hasTipoId) {
             $sets[] = self::COL_TIPO_ID . ' = :tipo_global';
             $params[':tipo_global'] = $tipoGlobalParam;
+        }
+
+        if ($hasTipoDepto) {
+            $sets[] = self::COL_TIPO_DEP . ' = :tipo_departamental';
+            $params[':tipo_departamental'] = $tipoDepartamentoParam;
         }
 
         $sql = '
@@ -661,6 +669,97 @@ final class IncidenciaRepository extends BaseRepository
     }
 
     /**
+     * Catálogo de tipos globales disponibles.
+     *
+     * @return array<int,array{id:int,nombre:string}>
+     */
+    public function catalogoTiposGlobales(): array
+    {
+        $sql = '
+            SELECT ' . self::TIPO_GLOBAL_ID . ' AS id, ' . self::TIPO_GLOBAL_NOMBRE . ' AS nombre
+            FROM ' . self::T_TIPOS_GLOBAL . '
+            ORDER BY ' . self::TIPO_GLOBAL_NOMBRE . '
+        ';
+
+        try {
+            $rows = $this->db->fetchAll($sql);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('No se pudo obtener el catálogo de tipos globales.', 0, $e);
+        }
+
+        $items = [];
+        foreach ($rows as $row) {
+            if (!isset($row['id'], $row['nombre'])) {
+                continue;
+            }
+            $items[] = [
+                'id'     => (int)$row['id'],
+                'nombre' => (string)$row['nombre'],
+            ];
+        }
+
+        return $items;
+    }
+
+    private function ensureTipoGlobalId(int $tipoId): int
+    {
+        $tipoGlobalId = $this->findTipoGlobalPorId($tipoId);
+        if ($tipoGlobalId !== null) {
+            return $tipoGlobalId;
+        }
+
+        return $this->findPrimerTipoGlobalId();
+    }
+
+    private function findTipoGlobalPorId(int $tipoId): ?int
+    {
+        if ($tipoId < 1) {
+            return null;
+        }
+
+        $sql = '
+            SELECT ' . self::TIPO_GLOBAL_ID . ' AS id
+            FROM ' . self::T_TIPOS_GLOBAL . '
+            WHERE ' . self::TIPO_GLOBAL_ID . ' = :id
+            LIMIT 1
+        ';
+
+        try {
+            $row = $this->db->fetch($sql, [':id' => [$tipoId, PDO::PARAM_INT]]);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('No se pudo validar el tipo global solicitado.', 0, $e);
+        }
+
+        if (!$row || !isset($row['id'])) {
+            return null;
+        }
+
+        return (int)$row['id'];
+    }
+
+    private function findPrimerTipoGlobalId(): int
+    {
+        $sql = '
+            SELECT ' . self::TIPO_GLOBAL_ID . ' AS id
+            FROM ' . self::T_TIPOS_GLOBAL . '
+            ORDER BY ' . self::TIPO_GLOBAL_NOMBRE . '
+            LIMIT 1
+        ';
+
+        try {
+            $row = $this->db->fetch($sql);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('No se pudo obtener un tipo global por defecto.', 0, $e);
+        }
+
+        if ($row && isset($row['id'])) {
+            return (int)$row['id'];
+        }
+
+        throw new RuntimeException('No se encontró un tipo global disponible.');
+    }
+
+    /**
      * Catálogo de tipos por departamento.
      *
      * @return array<int,array<int,array{id:int,departamento_id:int,nombre:string}>>
@@ -766,6 +865,35 @@ final class IncidenciaRepository extends BaseRepository
     }
 
     /**
+     * Devuelve el primer tipo disponible sin importar el departamento.
+     */
+    private function findPrimerTipoDisponible(): ?array
+    {
+        $sql = '
+            SELECT
+                ' . self::TIPO_ID . ' AS id,
+                ' . self::TIPO_DEPTO . ' AS departamento_id,
+                ' . self::TIPO_NOMBRE . ' AS nombre,
+                ' . self::TIPO_REF . ' AS referencia_id
+            FROM ' . self::T_TIPOS_DEP . '
+            ORDER BY ' . self::TIPO_ORDEN . ', ' . self::TIPO_NOMBRE . '
+            LIMIT 1
+        ';
+
+        try {
+            $row = $this->db->fetch($sql);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('No se pudo obtener un tipo de incidencia por defecto.', 0, $e);
+        }
+
+        if (!$row) {
+            return null;
+        }
+
+        return $this->normalizeTipoRow($row);
+    }
+
+    /**
      * Normaliza un registro de tipo departamental y lo almacena en caché.
      *
      * @param array<string,mixed> $row
@@ -782,18 +910,11 @@ final class IncidenciaRepository extends BaseRepository
         $nombre = (string)$row['nombre'];
         $referencia = isset($row['referencia_id']) ? (int)$row['referencia_id'] : 0;
 
-        $globalId = null;
-        if ($referencia > 0) {
-            $globalId = $referencia;
-        } else {
-            $globalId = $this->lookupTipoGlobalIdByNombre($nombre);
-        }
-
         $tipo = [
             'id'              => $id,
             'departamento_id' => $departamentoId,
             'nombre'          => $nombre,
-            'global_id'       => $globalId && $globalId > 0 ? $globalId : null,
+            'global_id'       => $referencia > 0 ? $referencia : null,
         ];
 
         $this->tipoDepartamentoCache[$id] = $tipo;
@@ -801,94 +922,29 @@ final class IncidenciaRepository extends BaseRepository
         return $tipo;
     }
 
-    private function normalizeNombreClave(string $value): string
+    private function resolveTipoDepartamentoId(int $tipoDepartamentoId, int $departamentoId): int
     {
-        $value = trim($value);
-        if ($value === '') {
-            return '';
-        }
-
-        return function_exists('mb_strtolower')
-            ? mb_strtolower($value, 'UTF-8')
-            : strtolower($value);
-    }
-
-    /**
-     * @return array<string,int>
-     */
-    private function tiposGlobalesMap(): array
-    {
-        if ($this->globalTipoMap !== null) {
-            return $this->globalTipoMap;
-        }
-
-        $sql = '
-            SELECT ' . self::TIPO_GLOBAL_ID . ' AS id, ' . self::TIPO_GLOBAL_NOMBRE . ' AS nombre
-            FROM ' . self::T_TIPOS_GLOBAL . '
-        ';
-
-        try {
-            $rows = $this->db->fetchAll($sql);
-        } catch (\Throwable $e) {
-            $this->globalTipoMap = [];
-            return $this->globalTipoMap;
-        }
-
-        $map = [];
-        foreach ($rows as $row) {
-            if (!isset($row['id'], $row['nombre'])) {
-                continue;
+        if ($tipoDepartamentoId > 0) {
+            $tipo = $this->findTipoPorId($tipoDepartamentoId);
+            if ($tipo !== null) {
+                return (int)$tipo['id'];
             }
-            $key = $this->normalizeNombreClave((string)$row['nombre']);
-            if ($key === '') {
-                continue;
-            }
-            $map[$key] = (int)$row['id'];
-        }
-
-        $this->globalTipoMap = $map;
-
-        return $this->globalTipoMap;
-    }
-
-    private function lookupTipoGlobalIdByNombre(string $nombre): ?int
-    {
-        $key = $this->normalizeNombreClave($nombre);
-        if ($key === '') {
-            return null;
-        }
-
-        $map = $this->tiposGlobalesMap();
-
-        return isset($map[$key]) ? (int)$map[$key] : null;
-    }
-
-    private function resolveTipoGlobalIdFor(int $tipoDepartamentoId, int $providedGlobalId, string $nombre): ?int
-    {
-        if ($providedGlobalId > 0) {
-            return $providedGlobalId;
         }
 
         $tipo = null;
-        if ($tipoDepartamentoId > 0) {
-            if (isset($this->tipoDepartamentoCache[$tipoDepartamentoId])) {
-                $tipo = $this->tipoDepartamentoCache[$tipoDepartamentoId];
-            } else {
-                $tipo = $this->findTipoPorId($tipoDepartamentoId);
-            }
+        if ($departamentoId > 0) {
+            $tipo = $this->findPrimerTipoPorDepartamento($departamentoId);
         }
 
-        if (is_array($tipo)) {
-            if (!empty($tipo['global_id'])) {
-                return (int)$tipo['global_id'];
-            }
-            if ($nombre === '') {
-                $nombre = (string)($tipo['nombre'] ?? '');
-            }
+        if ($tipo === null) {
+            $tipo = $this->findPrimerTipoDisponible();
         }
 
-        $global = $this->lookupTipoGlobalIdByNombre($nombre);
-        return $global !== null && $global > 0 ? $global : null;
+        if (is_array($tipo) && !empty($tipo['id'])) {
+            return (int)$tipo['id'];
+        }
+
+        return 1;
     }
 
     /**

--- a/app/Repositories/Comercial/SeguimientoRepository.php
+++ b/app/Repositories/Comercial/SeguimientoRepository.php
@@ -4,57 +4,41 @@ namespace App\Repositories\Comercial;
 use App\Repositories\BaseRepository;
 use PDO;
 use RuntimeException;
+use Throwable;
 
 final class SeguimientoRepository extends BaseRepository
 {
-    private const TABLE_CANDIDATES = [
-        'public.comercial_seguimientos',
-        'public.seguimientos_comercial',
-        'public.seguimientos_diarios',
-        'public.seguimiento_diario',
-        'public.seguimientos',
-    ];
-
-    private const TIPOS_TABLE_CANDIDATES = [
-        'public.seguimiento_tipos',
-        'public.tipos_seguimiento',
-        'public.tipos_seguimientos',
-    ];
-
-    private const TABLE_COOPS = 'public.cooperativas';
-    private const COOP_ID     = 'id_cooperativa';
-    private const COOP_NOMBRE = 'nombre';
-
-    /** @var string|null */
-    private $resolvedTable = null;
+    private const TABLE = 'public.comercial_seguimientos';
+    private const COOPS_TABLE = 'public.cooperativas';
+    private const CONTACTS_TABLE = 'public.contactos_cooperativa';
+    private const TICKETS_VIEW = 'public.v_tickets_busqueda';
+    private const USERS_TABLE = 'public.usuarios';
+    private const TIPOS_TABLE = 'public.seguimiento_tipos';
 
     /**
-     * @var array<string,array{name:string,type:string}>
-     */
-    private $columnInfo = [];
-
-    /**
-     * @param array $filters
-     * @param int $page
-     * @param int $perPage
-     * @return array{items:array<int,array<string,mixed>>, total:int, page:int, perPage:int}
+     * @param array<string,mixed> $filters
+     * @return array{items:array<int,array<string,mixed>>,total:int,page:int,perPage:int}
      */
     public function paginate(array $filters, int $page, int $perPage): array
     {
-        $parts = $this->queryParts();
-
-        $page    = max(1, $page);
+        $page = max(1, $page);
         $perPage = max(5, min(60, $perPage));
-        $offset  = ($page - 1) * $perPage;
+        $offset = ($page - 1) * $perPage;
 
-        [$whereSql, $params] = $this->buildFilters($filters, $parts);
+        $params = [];
+        $where = $this->buildFilters($filters, $params);
 
-        $countSql = "SELECT COUNT(*) AS total FROM {$parts['table']} s{$parts['joinsSql']}" . ($whereSql !== '' ? " $whereSql" : '');
+        $joins = ' INNER JOIN ' . self::COOPS_TABLE . ' c ON c.id_cooperativa = s.id_cooperativa'
+            . ' LEFT JOIN ' . self::USERS_TABLE . ' u ON u.id_usuario = s.creado_por'
+            . ' LEFT JOIN ' . self::CONTACTS_TABLE . ' cc ON cc.id_contacto = s.id_contacto'
+            . ' LEFT JOIN ' . self::TICKETS_VIEW . ' vt ON vt.id_ticket = s.ticket_id';
+
+        $countSql = 'SELECT COUNT(*) AS total FROM ' . self::TABLE . ' s' . $joins . ($where !== '' ? ' ' . $where : '');
 
         try {
             $countRow = $this->db->fetch($countSql, $params);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al contar el historial de seguimiento.', 0, $e);
+        } catch (Throwable $e) {
+            throw new RuntimeException('Error al contar los seguimientos.', 0, $e);
         }
 
         $total = $countRow ? (int)$countRow['total'] : 0;
@@ -67,17 +51,21 @@ final class SeguimientoRepository extends BaseRepository
             ];
         }
 
-        $params[':limit']  = [$perPage, PDO::PARAM_INT];
+        $params[':limit'] = [$perPage, PDO::PARAM_INT];
         $params[':offset'] = [$offset, PDO::PARAM_INT];
 
-        $sql = "SELECT {$parts['select']} FROM {$parts['table']} s{$parts['joinsSql']}"
-            . ($whereSql !== '' ? " $whereSql" : '')
-            . " ORDER BY {$parts['orderBy']} LIMIT :limit OFFSET :offset";
+        $select = $this->selectClause();
+        $sql = 'SELECT ' . $select
+            . ' FROM ' . self::TABLE . ' s'
+            . $joins
+            . ($where !== '' ? ' ' . $where : '')
+            . ' ORDER BY s.fecha_actividad DESC, s.id DESC'
+            . ' LIMIT :limit OFFSET :offset';
 
         try {
             $rows = $this->db->fetchAll($sql, $params);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al obtener el historial de seguimiento.', 0, $e);
+        } catch (Throwable $e) {
+            throw new RuntimeException('Error al obtener el historial de seguimientos.', 0, $e);
         }
 
         $items = [];
@@ -92,24 +80,28 @@ final class SeguimientoRepository extends BaseRepository
             'perPage' => $perPage,
         ];
     }
-
     /**
-     * @param array $filters
+     * @param array<string,mixed> $filters
      * @return array<int,array<string,mixed>>
      */
     public function listarParaExportar(array $filters): array
     {
-        $parts = $this->queryParts();
-        [$whereSql, $params] = $this->buildFilters($filters, $parts);
+        $params = [];
+        $where = $this->buildFilters($filters, $params);
 
-        $sql = "SELECT {$parts['select']} FROM {$parts['table']} s{$parts['joinsSql']}"
-            . ($whereSql !== '' ? " $whereSql" : '')
-            . " ORDER BY {$parts['orderBy']}";
+        $sql = 'SELECT ' . $this->selectClause()
+            . ' FROM ' . self::TABLE . ' s'
+            . ' INNER JOIN ' . self::COOPS_TABLE . ' c ON c.id_cooperativa = s.id_cooperativa'
+            . ' LEFT JOIN ' . self::USERS_TABLE . ' u ON u.id_usuario = s.creado_por'
+            . ' LEFT JOIN ' . self::CONTACTS_TABLE . ' cc ON cc.id_contacto = s.id_contacto'
+            . ' LEFT JOIN ' . self::TICKETS_VIEW . ' vt ON vt.id_ticket = s.ticket_id'
+            . ($where !== '' ? ' ' . $where : '')
+            . ' ORDER BY s.fecha_actividad DESC, s.id DESC';
 
         try {
             $rows = $this->db->fetchAll($sql, $params);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Error al exportar el historial de seguimiento.', 0, $e);
+        } catch (Throwable $e) {
+            throw new RuntimeException('Error al exportar el historial de seguimientos.', 0, $e);
         }
 
         $items = [];
@@ -125,110 +117,37 @@ final class SeguimientoRepository extends BaseRepository
      */
     public function create(array $data): int
     {
-        $table   = $this->resolveTable();
-        $idCol   = $this->requireColumn('id');
-        $coopCol = $this->requireColumn('coop');
+        $sql = 'INSERT INTO ' . self::TABLE . ' (
+                id_cooperativa,
+                fecha_actividad,
+                fecha_finalizacion,
+                tipo,
+                descripcion,
+                id_contacto,
+                datos_reunion,
+                datos_ticket,
+                ticket_id,
+                creado_por,
+                created_at
+            ) VALUES (
+                :id_cooperativa,
+                :fecha_inicio,
+                :fecha_fin,
+                :tipo,
+                :descripcion,
+                :id_contacto,
+                :datos_reunion,
+                :datos_ticket,
+                :ticket_id,
+                :creado_por,
+                NOW()
+            ) RETURNING id';
 
-        $columns = [$coopCol];
-        $values  = [':coop'];
-        $params  = [
-            ':coop' => [$data['id_cooperativa'] ?? 0, PDO::PARAM_INT],
-        ];
-
-        $fechaCol = $this->column('fecha');
-        if ($fechaCol !== null) {
-            $columns[] = $fechaCol;
-            $values[]  = ':fecha';
-            $params[':fecha'] = [$data['fecha'] ?? date('Y-m-d'), PDO::PARAM_STR];
-        }
-
-        $tipoCol = $this->column('tipo');
-        if ($tipoCol !== null) {
-            $columns[] = $tipoCol;
-            $values[]  = ':tipo';
-            $params[':tipo'] = [
-                (string)($data['tipo'] ?? ''),
-                PDO::PARAM_STR,
-            ];
-        }
-
-        $descCol = $this->requireColumn('descripcion');
-        $columns[] = $descCol;
-        $values[]  = ':descripcion';
-        $params[':descripcion'] = [
-            (string)($data['descripcion'] ?? ''),
-            PDO::PARAM_STR,
-        ];
-
-        $ticketCol = $this->column('ticket');
-        $contactNumberCol = $this->column('contact_number');
-        $contactDataCol   = $this->column('contact_data');
-        if ($ticketCol !== null) {
-            $columns[] = $ticketCol;
-            $values[]  = ':ticket';
-
-            $ticketValue = $data['ticket'] ?? null;
-            if ($ticketValue === '' || $ticketValue === null) {
-                $params[':ticket'] = [null, PDO::PARAM_NULL];
-            } elseif ($this->columnIsNumeric('ticket')) {
-                $params[':ticket'] = [(int)$ticketValue, PDO::PARAM_INT];
-            } else {
-                $params[':ticket'] = [(string)$ticketValue, PDO::PARAM_STR];
-            }
-        }
-
-        if ($contactNumberCol !== null) {
-            $columns[] = $contactNumberCol;
-            $values[]  = ':contact_number';
-
-            $numberValue = $data['numero_contacto'] ?? null;
-            if ($numberValue === '' || $numberValue === null) {
-                $params[':contact_number'] = [null, PDO::PARAM_NULL];
-            } else {
-                $params[':contact_number'] = [(int)$numberValue, PDO::PARAM_INT];
-            }
-        }
-
-        if ($contactDataCol !== null) {
-            $columns[] = $contactDataCol;
-            $values[]  = ':contact_data';
-
-            $rawContact = $data['datos_contacto'] ?? null;
-            if ($rawContact === null || $rawContact === '') {
-                $params[':contact_data'] = [null, PDO::PARAM_NULL];
-            } else {
-                $json = $rawContact;
-                if (is_array($rawContact)) {
-                    $json = json_encode($rawContact, JSON_UNESCAPED_UNICODE);
-                }
-                if (!is_string($json) || $json === false) {
-                    $json = json_encode(['valor' => (string)$rawContact], JSON_UNESCAPED_UNICODE);
-                }
-                $params[':contact_data'] = [$json, PDO::PARAM_STR];
-            }
-        }
-
-        $usuarioCol = $this->column('usuario');
-        if ($usuarioCol !== null) {
-            $columns[] = $usuarioCol;
-            $values[]  = ':usuario';
-
-            $usuario = $data['creado_por'] ?? null;
-            if ($usuario === null) {
-                $params[':usuario'] = [null, PDO::PARAM_NULL];
-            } else {
-                $params[':usuario'] = [(int)$usuario, PDO::PARAM_INT];
-            }
-        }
-
-        $sql = 'INSERT INTO ' . $table
-            . ' (' . implode(', ', $columns) . ')
-               VALUES (' . implode(', ', $values) . ')
-               RETURNING ' . $idCol . ' AS id';
+        $params = $this->buildPersistenceParams($data, false);
 
         try {
             $result = $this->db->execute($sql, $params);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             throw new RuntimeException('No se pudo registrar el seguimiento.', 0, $e);
         }
 
@@ -237,32 +156,77 @@ final class SeguimientoRepository extends BaseRepository
     }
 
     /**
+     * @param array<string,mixed> $data
+     */
+    public function update(int $id, array $data): void
+    {
+        $sql = 'UPDATE ' . self::TABLE . ' SET
+                id_cooperativa = :id_cooperativa,
+                fecha_actividad = :fecha_inicio,
+                fecha_finalizacion = :fecha_fin,
+                tipo = :tipo,
+                descripcion = :descripcion,
+                id_contacto = :id_contacto,
+                datos_reunion = :datos_reunion,
+                datos_ticket = :datos_ticket,
+                ticket_id = :ticket_id,
+                editado_por = :usuario_editor,
+                editado_en = NOW()
+            WHERE id = :id';
+
+        $params = $this->buildPersistenceParams($data, true);
+        $params[':id'] = [$id, PDO::PARAM_INT];
+
+        try {
+            $this->db->execute($sql, $params);
+        } catch (Throwable $e) {
+            throw new RuntimeException('No se pudo actualizar el seguimiento.', 0, $e);
+        }
+    }
+    public function find(int $id): ?array
+    {
+        $sql = 'SELECT ' . $this->selectClause()
+            . ' FROM ' . self::TABLE . ' s'
+            . ' INNER JOIN ' . self::COOPS_TABLE . ' c ON c.id_cooperativa = s.id_cooperativa'
+            . ' LEFT JOIN ' . self::USERS_TABLE . ' u ON u.id_usuario = s.creado_por'
+            . ' LEFT JOIN ' . self::CONTACTS_TABLE . ' cc ON cc.id_contacto = s.id_contacto'
+            . ' LEFT JOIN ' . self::TICKETS_VIEW . ' vt ON vt.id_ticket = s.ticket_id'
+            . ' WHERE s.id = :id';
+
+        try {
+            $row = $this->db->fetch($sql, [':id' => [$id, PDO::PARAM_INT]]);
+        } catch (Throwable $e) {
+            throw new RuntimeException('No se pudo obtener el seguimiento solicitado.', 0, $e);
+        }
+
+        return $row ? $this->mapRow($row) : null;
+    }
+
+    /**
      * @return array<int,array{id:int,nombre:string}>
      */
     public function listadoCooperativas(): array
     {
-        $sql = 'SELECT ' . self::COOP_ID . ' AS id, ' . self::COOP_NOMBRE . ' AS nombre'
-            . ' FROM ' . self::TABLE_COOPS
-            . ' ORDER BY ' . self::COOP_NOMBRE . ' ASC';
+        $sql = 'SELECT id_cooperativa AS id, nombre FROM ' . self::COOPS_TABLE . ' WHERE activa = true ORDER BY nombre ASC';
 
         try {
             $rows = $this->db->fetchAll($sql);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('No se pudieron obtener las cooperativas.', 0, $e);
+        } catch (Throwable $e) {
+            throw new RuntimeException('No se pudieron obtener las entidades.', 0, $e);
         }
 
-        $list = [];
+        $items = [];
         foreach ($rows as $row) {
             if (!isset($row['id'], $row['nombre'])) {
                 continue;
             }
-            $list[] = [
+            $items[] = [
                 'id'     => (int)$row['id'],
                 'nombre' => (string)$row['nombre'],
             ];
         }
 
-        return $list;
+        return $items;
     }
 
     /**
@@ -270,193 +234,321 @@ final class SeguimientoRepository extends BaseRepository
      */
     public function catalogoTipos(): array
     {
-        foreach (self::TIPOS_TABLE_CANDIDATES as $candidate) {
-            [$schema, $table] = $this->splitTableName($candidate);
-            if (!$this->tableExists($schema, $table)) {
-                continue;
-            }
+        $sql = 'SELECT nombre FROM ' . self::TIPOS_TABLE . ' WHERE nombre <> :omit ORDER BY orden ASC, nombre ASC';
 
-            $column = $this->findColumnName($schema, $table, ['nombre', 'descripcion', 'titulo', 'etiqueta']);
-            if ($column === null) {
-                continue;
-            }
-
-            $sql = 'SELECT ' . $column . ' AS nombre FROM ' . $schema . '.' . $table . ' ORDER BY ' . $column . ' ASC';
-            try {
-                $rows = $this->db->fetchAll($sql);
-            } catch (\Throwable $e) {
-                continue;
-            }
-
-            $tipos = [];
-            foreach ($rows as $row) {
-                if (!isset($row['nombre'])) {
-                    continue;
-                }
-                $value = trim((string)$row['nombre']);
-                if ($value !== '') {
-                    $tipos[] = $value;
-                }
-            }
-
-            if ($tipos) {
-                return $tipos;
-            }
+        try {
+            $rows = $this->db->fetchAll($sql, [':omit' => ['Seguimiento', PDO::PARAM_STR]]);
+        } catch (Throwable $e) {
+            return ['Contacto', 'Reunión', 'Ticket'];
         }
 
-        return ['Contacto', 'Soporte', 'Ticket', 'Reunión', 'Seguimiento'];
+        $tipos = [];
+        foreach ($rows as $row) {
+            if (!isset($row['nombre'])) {
+                continue;
+            }
+            $value = trim((string)$row['nombre']);
+            if ($value === '' || strcasecmp($value, 'Seguimiento') === 0) {
+                continue;
+            }
+            $tipos[] = $value;
+        }
+
+        if (!$tipos) {
+            $tipos = ['Contacto', 'Reunión', 'Ticket'];
+        }
+
+        return array_values(array_unique($tipos));
     }
 
     /**
-     * @return array<string,mixed>
+     * @return array<int,array{id:int,nombre:string,telefono:?string,email:?string}>
      */
-    private function queryParts(): array
+    public function contactosPorEntidad(int $entidadId): array
     {
-        $table = $this->resolveTable();
-
-        $idCol    = $this->requireColumn('id');
-        $coopCol  = $this->requireColumn('coop');
-        $descCol  = $this->requireColumn('descripcion');
-        $fechaCol = $this->column('fecha');
-        $tipoCol  = $this->column('tipo');
-        $ticketCol = $this->column('ticket');
-        $contactNumberCol = $this->column('contact_number');
-        $contactDataCol   = $this->column('contact_data');
-        $usuarioCol = $this->column('usuario');
-        $createdCol = $this->column('created');
-
-        $selectParts = [
-            's.' . $idCol . ' AS id',
-            's.' . $coopCol . ' AS id_cooperativa',
-            'c.' . self::COOP_NOMBRE . ' AS cooperativa',
-            ($fechaCol !== null
-                ? 's.' . $fechaCol
-                : ($createdCol !== null ? 'DATE(s.' . $createdCol . ')' : 'CURRENT_DATE')
-            ) . ' AS fecha_registro',
-            "COALESCE(s." . $descCol . ", '') AS descripcion",
-        ];
-
-        if ($tipoCol !== null) {
-            $selectParts[] = "COALESCE(s." . $tipoCol . ", '') AS tipo";
-        } else {
-            $selectParts[] = "'' AS tipo";
+        if ($entidadId <= 0) {
+            return [];
         }
 
-        if ($ticketCol !== null) {
-            $selectParts[] = 's.' . $ticketCol . ' AS ticket';
-        } else {
-            $selectParts[] = 'NULL AS ticket';
+        $sql = 'SELECT id_contacto AS id, nombre_contacto AS nombre, telefono, email'
+            . ' FROM ' . self::CONTACTS_TABLE
+            . ' WHERE id_cooperativa = :id AND activo = true'
+            . ' ORDER BY nombre_contacto ASC';
+
+        try {
+            $rows = $this->db->fetchAll($sql, [':id' => [$entidadId, PDO::PARAM_INT]]);
+        } catch (Throwable $e) {
+            throw new RuntimeException('No se pudieron obtener los contactos de la entidad.', 0, $e);
         }
 
-        if ($createdCol !== null) {
-            $selectParts[] = 's.' . $createdCol . ' AS creado_en';
-        } else {
-            $selectParts[] = 'NULL AS creado_en';
+        $items = [];
+        foreach ($rows as $row) {
+            if (!isset($row['id'], $row['nombre'])) {
+                continue;
+            }
+            $items[] = [
+                'id'       => (int)$row['id'],
+                'nombre'   => (string)$row['nombre'],
+                'telefono' => isset($row['telefono']) ? (string)$row['telefono'] : null,
+                'email'    => isset($row['email']) ? (string)$row['email'] : null,
+            ];
         }
 
-        if ($contactNumberCol !== null) {
-            $selectParts[] = 's.' . $contactNumberCol . ' AS contact_number';
-        } else {
-            $selectParts[] = 'NULL AS contact_number';
+        return $items;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function buscarTickets(string $term): array
+    {
+        $term = trim($term);
+        if ($term === '') {
+            return [];
         }
 
-        if ($contactDataCol !== null) {
-            $selectParts[] = 's.' . $contactDataCol . ' AS contact_data';
-        } else {
-            $selectParts[] = 'NULL AS contact_data';
+        $sql = 'SELECT id_ticket, codigo_ticket, titulo, departamento_nombre, nombre_categoria, prioridad, estado'
+            . ' FROM ' . self::TICKETS_VIEW
+            . ' WHERE codigo_ticket ILIKE :term OR titulo ILIKE :term'
+            . ' ORDER BY fecha_apertura DESC'
+            . ' LIMIT 15';
+
+        try {
+            $rows = $this->db->fetchAll($sql, [':term' => ['%' . $term . '%', PDO::PARAM_STR]]);
+        } catch (Throwable $e) {
+            throw new RuntimeException('No se pudo buscar tickets.', 0, $e);
         }
 
-        $joins = [
-            ' INNER JOIN ' . self::TABLE_COOPS . ' c ON c.' . self::COOP_ID . ' = s.' . $coopCol,
-        ];
-
-        if ($usuarioCol !== null) {
-            $selectParts[] = 's.' . $usuarioCol . ' AS usuario_id';
-            $selectParts[] = "COALESCE(u.nombre_completo, u.username, '') AS usuario_nombre";
-            $joins[] = ' LEFT JOIN public.usuarios u ON u.id_usuario = s.' . $usuarioCol;
-        } else {
-            $selectParts[] = 'NULL AS usuario_id';
-            $selectParts[] = "'' AS usuario_nombre";
+        $items = [];
+        foreach ($rows as $row) {
+            if (!isset($row['id_ticket'], $row['codigo_ticket'])) {
+                continue;
+            }
+            $items[] = [
+                'id'          => (int)$row['id_ticket'],
+                'codigo'      => (string)$row['codigo_ticket'],
+                'titulo'      => isset($row['titulo']) ? (string)$row['titulo'] : '',
+                'departamento'=> isset($row['departamento_nombre']) ? (string)$row['departamento_nombre'] : '',
+                'tipo'        => isset($row['nombre_categoria']) ? (string)$row['nombre_categoria'] : '',
+                'prioridad'   => isset($row['prioridad']) ? (string)$row['prioridad'] : '',
+                'estado'      => isset($row['estado']) ? (string)$row['estado'] : '',
+            ];
         }
 
-        $orderBy = $fechaCol !== null
-            ? 's.' . $fechaCol . ' DESC'
-            : ($createdCol !== null ? 's.' . $createdCol . ' DESC' : 's.' . $idCol . ' DESC');
+        return $items;
+    }
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function ticketPorId(int $ticketId): ?array
+    {
+        if ($ticketId <= 0) {
+            return null;
+        }
 
-        $joinsSql = '';
-        foreach ($joins as $join) {
-            $joinsSql .= $join;
+        $sql = 'SELECT id_ticket, codigo_ticket, titulo, departamento_nombre, nombre_categoria, prioridad, estado'
+            . ' FROM ' . self::TICKETS_VIEW
+            . ' WHERE id_ticket = :id'
+            . ' LIMIT 1';
+
+        try {
+            $row = $this->db->fetch($sql, [':id' => [$ticketId, PDO::PARAM_INT]]);
+        } catch (Throwable $e) {
+            throw new RuntimeException('No se pudo obtener la información del ticket.', 0, $e);
+        }
+
+        if (!$row) {
+            return null;
         }
 
         return [
-            'table'            => $table,
-            'select'           => implode(",
-                ", $selectParts),
-            'joinsSql'         => $joinsSql,
-            'orderBy'          => $orderBy,
-            'fechaFilter'      => $fechaCol !== null ? 'DATE(s.' . $fechaCol . ')' : ($createdCol !== null ? 'DATE(s.' . $createdCol . ')' : null),
-            'tipoFilter'       => $tipoCol !== null ? 's.' . $tipoCol : null,
-            'ticketFilter'     => $ticketCol !== null ? 's.' . $ticketCol : null,
-            'descripcionCol'   => 's.' . $descCol,
-            'contactNumberCol' => $contactNumberCol !== null ? 's.' . $contactNumberCol : null,
-            'contactDataCol'   => $contactDataCol !== null ? 's.' . $contactDataCol : null,
+            'id'          => (int)$row['id_ticket'],
+            'codigo'      => isset($row['codigo_ticket']) ? (string)$row['codigo_ticket'] : '',
+            'titulo'      => isset($row['titulo']) ? (string)$row['titulo'] : '',
+            'departamento'=> isset($row['departamento_nombre']) ? (string)$row['departamento_nombre'] : '',
+            'tipo'        => isset($row['nombre_categoria']) ? (string)$row['nombre_categoria'] : '',
+            'prioridad'   => isset($row['prioridad']) ? (string)$row['prioridad'] : '',
+            'estado'      => isset($row['estado']) ? (string)$row['estado'] : '',
         ];
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function buscarTicketsSeguimiento(string $term): array
+    {
+        $term = trim($term);
+        if ($term === '') {
+            return [];
+        }
+
+        $sql = 'SELECT DISTINCT'
+            . ' s.ticket_id,'
+            . ' COALESCE(s.datos_ticket->>\'codigo\', \'\') AS codigo,'
+            . ' LEFT(COALESCE(s.datos_ticket->>\'descripcion\', s.descripcion), 120) AS descripcion'
+            . ' FROM ' . self::TABLE . ' s'
+            . ' WHERE ('
+            . ' (s.ticket_id IS NOT NULL AND CAST(s.ticket_id AS TEXT) ILIKE :term)'
+            . ' OR (COALESCE(s.datos_ticket->>\'codigo\', \'\') ILIKE :term)'
+            . ' OR (s.descripcion ILIKE :term)'
+            . ' )'
+            . ' ORDER BY COALESCE(s.ticket_id, 0) DESC, codigo DESC, s.fecha_actividad DESC'
+            . ' LIMIT 10';
+
+        try {
+            $rows = $this->db->fetchAll($sql, [':term' => ['%' . $term . '%', PDO::PARAM_STR]]);
+        } catch (Throwable $e) {
+            throw new RuntimeException('No se pudieron obtener los tickets registrados en seguimiento.', 0, $e);
+        }
+
+        $items = [];
+        foreach ($rows as $row) {
+            $ticketId = isset($row['ticket_id']) ? (int)$row['ticket_id'] : 0;
+            $codigo = isset($row['codigo']) ? (string)$row['codigo'] : '';
+            if ($codigo === '' && $ticketId > 0) {
+                $codigo = 'Ticket #' . $ticketId;
+            }
+            $items[] = [
+                'ticket_id'   => $ticketId,
+                'codigo'      => $codigo,
+                'descripcion' => isset($row['descripcion']) ? (string)$row['descripcion'] : '',
+            ];
+        }
+
+        return $items;
+    }
+
+    public function delete(int $id): void
+    {
+        if ($id <= 0) {
+            throw new RuntimeException('El identificador del seguimiento no es válido.');
+        }
+
+        $sql = 'DELETE FROM ' . self::TABLE . ' WHERE id = :id';
+
+        try {
+            $this->db->execute($sql, [':id' => [$id, PDO::PARAM_INT]]);
+        } catch (Throwable $e) {
+            throw new RuntimeException('No se pudo eliminar el seguimiento.', 0, $e);
+        }
     }
 
     /**
      * @param array<string,mixed> $filters
-     * @param array<string,mixed> $parts
-     * @return array{0:string,1:array<string,array{0:mixed,1:int}>}
+     * @param array<string,array{0:mixed,1:int}> $params
      */
-    private function buildFilters(array $filters, array $parts): array
+    private function buildFilters(array $filters, array &$params): string
     {
         $conditions = [];
-        $params = [];
 
         $fecha = isset($filters['fecha']) ? trim((string)$filters['fecha']) : '';
-        if ($fecha !== '' && $parts['fechaFilter'] !== null) {
-            $conditions[] = $parts['fechaFilter'] . ' = :fecha';
+        if ($fecha !== '') {
+            $conditions[] = 'DATE(s.fecha_actividad) = :fecha';
             $params[':fecha'] = [$fecha, PDO::PARAM_STR];
         } else {
             $desde = isset($filters['desde']) ? trim((string)$filters['desde']) : '';
-            $hasta = isset($filters['hasta']) ? trim((string)$filters['hasta']) : '';
-            if ($desde !== '' && $parts['fechaFilter'] !== null) {
-                $conditions[] = $parts['fechaFilter'] . ' >= :desde';
+            if ($desde !== '') {
+                $conditions[] = 'DATE(s.fecha_actividad) >= :desde';
                 $params[':desde'] = [$desde, PDO::PARAM_STR];
             }
-            if ($hasta !== '' && $parts['fechaFilter'] !== null) {
-                $conditions[] = $parts['fechaFilter'] . ' <= :hasta';
+            $hasta = isset($filters['hasta']) ? trim((string)$filters['hasta']) : '';
+            if ($hasta !== '') {
+                $conditions[] = 'DATE(s.fecha_actividad) <= :hasta';
                 $params[':hasta'] = [$hasta, PDO::PARAM_STR];
             }
         }
 
         $coop = isset($filters['coop']) ? (int)$filters['coop'] : 0;
         if ($coop > 0) {
-            $conditions[] = 's.' . $this->requireColumn('coop') . ' = :coop';
+            $conditions[] = 's.id_cooperativa = :coop';
             $params[':coop'] = [$coop, PDO::PARAM_INT];
         }
 
         $tipo = isset($filters['tipo']) ? trim((string)$filters['tipo']) : '';
-        if ($tipo !== '' && $parts['tipoFilter'] !== null) {
-            $conditions[] = $parts['tipoFilter'] . ' = :tipo';
+        if ($tipo !== '') {
+            $conditions[] = 's.tipo = :tipo';
             $params[':tipo'] = [$tipo, PDO::PARAM_STR];
         }
 
         $ticket = isset($filters['ticket']) ? trim((string)$filters['ticket']) : '';
-        if ($ticket !== '' && $parts['ticketFilter'] !== null) {
-            $conditions[] = $parts['ticketFilter'] . '::text ILIKE :ticket';
+        if ($ticket !== '') {
+            $conditions[] = '((CAST(s.ticket_id AS TEXT) ILIKE :ticket)'
+                . ' OR (COALESCE(s.datos_ticket::text, \'\') ILIKE :ticket))';
             $params[':ticket'] = ['%' . $ticket . '%', PDO::PARAM_STR];
         }
 
         $texto = isset($filters['q']) ? trim((string)$filters['q']) : '';
         if ($texto !== '') {
-            $conditions[] = $parts['descripcionCol'] . ' ILIKE :texto';
+            $conditions[] = 's.descripcion ILIKE :texto';
             $params[':texto'] = ['%' . $texto . '%', PDO::PARAM_STR];
         }
 
-        $whereSql = $conditions ? 'WHERE ' . implode(' AND ', $conditions) : '';
+        return $conditions ? 'WHERE ' . implode(' AND ', $conditions) : '';
+    }
 
-        return [$whereSql, $params];
+    private function selectClause(): string
+    {
+        return implode(', ', [
+            's.id',
+            's.id_cooperativa',
+            'c.nombre AS cooperativa',
+            's.fecha_actividad::date AS fecha_actividad',
+            's.fecha_finalizacion::date AS fecha_finalizacion',
+            's.tipo',
+            's.descripcion',
+            's.id_contacto',
+            's.datos_reunion',
+            's.datos_ticket',
+            's.ticket_id',
+            's.creado_por',
+            's.created_at::date AS created_at',
+            's.editado_por',
+            's.editado_en::date AS editado_en',
+            "COALESCE(u.nombre_completo, u.username, '') AS usuario_nombre",
+            'u.id_usuario AS usuario_id',
+            'cc.nombre_contacto',
+            'cc.telefono AS contacto_telefono',
+            'cc.email AS contacto_email',
+            'vt.codigo_ticket',
+            'vt.departamento_nombre',
+            'vt.nombre_categoria',
+            'vt.prioridad',
+            'vt.estado'
+        ]);
+    }
+    /**
+     * @param array<string,mixed> $data
+     * @return array<string,array{0:mixed,1:int}>
+     */
+    private function buildPersistenceParams(array $data, bool $forUpdate): array
+    {
+        $params = [
+            ':id_cooperativa' => [$data['id_cooperativa'] ?? 0, PDO::PARAM_INT],
+            ':fecha_inicio'   => [$data['fecha_inicio'] ?? null, $this->paramType($data['fecha_inicio'] ?? null)],
+            ':fecha_fin'      => [$data['fecha_fin'] ?? null, $this->paramType($data['fecha_fin'] ?? null)],
+            ':tipo'           => [$data['tipo'] ?? '', PDO::PARAM_STR],
+            ':descripcion'    => [$data['descripcion'] ?? '', PDO::PARAM_STR],
+            ':id_contacto'    => [$data['id_contacto'] ?? null, $this->paramType($data['id_contacto'] ?? null, true)],
+            ':datos_reunion'  => [$data['datos_reunion'] ?? null, $this->paramType($data['datos_reunion'] ?? null)],
+            ':datos_ticket'   => [$data['datos_ticket'] ?? null, $this->paramType($data['datos_ticket'] ?? null)],
+            ':ticket_id'      => [$data['ticket_id'] ?? null, $this->paramType($data['ticket_id'] ?? null, true)],
+        ];
+
+        if ($forUpdate) {
+            $params[':usuario_editor'] = [$data['usuario_editor'] ?? null, $this->paramType($data['usuario_editor'] ?? null, true)];
+        } else {
+            $params[':creado_por'] = [$data['creado_por'] ?? null, $this->paramType($data['creado_por'] ?? null, true)];
+        }
+
+        return $params;
+    }
+
+    private function paramType($value, bool $isInt = false): int
+    {
+        if ($value === null || $value === '') {
+            return PDO::PARAM_NULL;
+        }
+        return $isInt ? PDO::PARAM_INT : PDO::PARAM_STR;
     }
 
     /**
@@ -465,218 +557,71 @@ final class SeguimientoRepository extends BaseRepository
      */
     private function mapRow(array $row): array
     {
+        $fechaInicio = isset($row['fecha_actividad']) ? (string)$row['fecha_actividad'] : '';
+        $fechaFin = isset($row['fecha_finalizacion']) ? (string)$row['fecha_finalizacion'] : '';
+
+        $datosTicket = null;
+        if (isset($row['datos_ticket']) && $row['datos_ticket'] !== null && $row['datos_ticket'] !== '') {
+            $decoded = json_decode((string)$row['datos_ticket'], true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $datosTicket = $decoded;
+            }
+        }
+
+        $datosReunion = null;
+        if (isset($row['datos_reunion']) && $row['datos_reunion'] !== null && $row['datos_reunion'] !== '') {
+            $decoded = json_decode((string)$row['datos_reunion'], true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $datosReunion = $decoded;
+            }
+        }
+
+        $ticketCodigo = isset($row['codigo_ticket']) ? (string)$row['codigo_ticket'] : '';
+        $ticketPrioridad = isset($row['prioridad']) ? (string)$row['prioridad'] : '';
+        $ticketEstado = isset($row['estado']) ? (string)$row['estado'] : '';
+        $ticketDepartamento = isset($row['departamento_nombre']) ? (string)$row['departamento_nombre'] : '';
+        $ticketTipo = isset($row['nombre_categoria']) ? (string)$row['nombre_categoria'] : '';
+
+        if ($datosTicket === null && $ticketCodigo !== '') {
+            $datosTicket = [
+                'codigo'       => $ticketCodigo,
+                'departamento' => $ticketDepartamento,
+                'tipo'         => $ticketTipo,
+                'prioridad'    => $ticketPrioridad,
+                'estado'       => $ticketEstado,
+            ];
+        }
+
         $usuarioNombre = isset($row['usuario_nombre']) ? trim((string)$row['usuario_nombre']) : '';
         $usuarioId = isset($row['usuario_id']) ? (int)$row['usuario_id'] : 0;
         if ($usuarioNombre === '' && $usuarioId > 0) {
             $usuarioNombre = 'Usuario #' . $usuarioId;
         }
 
-        $contactNumber = null;
-        if (isset($row['contact_number'])) {
-            $contactNumber = is_numeric($row['contact_number']) ? (int)$row['contact_number'] : null;
-            if ($contactNumber !== null && $contactNumber <= 0) {
-                $contactNumber = null;
-            }
-        }
-
-        $contactData = null;
-        if (isset($row['contact_data'])) {
-            $raw = $row['contact_data'];
-            if (is_string($raw) && $raw !== '') {
-                $decoded = json_decode($raw, true);
-                if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
-                    $contactData = $decoded;
-                } else {
-                    $contactData = $raw;
-                }
-            } elseif (is_array($raw)) {
-                $contactData = $raw;
-            }
-        }
-
         return [
-            'id'             => isset($row['id']) ? (int)$row['id'] : 0,
-            'cooperativa'    => isset($row['cooperativa']) ? (string)$row['cooperativa'] : '',
-            'fecha'          => isset($row['fecha_registro']) ? (string)$row['fecha_registro'] : '',
-            'tipo'           => isset($row['tipo']) ? (string)$row['tipo'] : '',
-            'descripcion'    => isset($row['descripcion']) ? (string)$row['descripcion'] : '',
-            'ticket'         => isset($row['ticket']) ? (string)$row['ticket'] : '',
-            'usuario'        => $usuarioNombre,
-            'usuario_id'     => $usuarioId,
-            'creado_en'      => isset($row['creado_en']) ? (string)$row['creado_en'] : '',
-            'contact_number' => $contactNumber,
-            'contact_data'   => $contactData,
+            'id'                   => isset($row['id']) ? (int)$row['id'] : 0,
+            'id_cooperativa'       => isset($row['id_cooperativa']) ? (int)$row['id_cooperativa'] : 0,
+            'cooperativa'          => isset($row['cooperativa']) ? (string)$row['cooperativa'] : '',
+            'fecha_inicio'         => $fechaInicio,
+            'fecha_fin'            => $fechaFin,
+            'tipo'                 => isset($row['tipo']) ? (string)$row['tipo'] : '',
+            'descripcion'          => isset($row['descripcion']) ? (string)$row['descripcion'] : '',
+            'id_contacto'          => isset($row['id_contacto']) ? (int)$row['id_contacto'] : null,
+            'contacto_nombre'      => isset($row['nombre_contacto']) ? (string)$row['nombre_contacto'] : '',
+            'contacto_telefono'    => isset($row['contacto_telefono']) ? (string)$row['contacto_telefono'] : '',
+            'contacto_email'       => isset($row['contacto_email']) ? (string)$row['contacto_email'] : '',
+            'ticket_id'            => isset($row['ticket_id']) ? (int)$row['ticket_id'] : null,
+            'ticket_codigo'        => $ticketCodigo,
+            'ticket_departamento'  => $ticketDepartamento,
+            'ticket_tipo'          => $ticketTipo,
+            'ticket_prioridad'     => $ticketPrioridad,
+            'ticket_estado'        => $ticketEstado,
+            'datos_ticket'         => $datosTicket,
+            'datos_reunion'        => $datosReunion,
+            'creado_en'            => isset($row['created_at']) ? (string)$row['created_at'] : '',
+            'usuario'              => $usuarioNombre,
+            'usuario_id'           => $usuarioId,
+            'editado_en'           => isset($row['editado_en']) ? (string)$row['editado_en'] : null,
         ];
-    }
-
-    private function resolveTable(): string
-    {
-        if ($this->resolvedTable !== null) {
-            return $this->resolvedTable;
-        }
-
-        foreach (self::TABLE_CANDIDATES as $candidate) {
-            [$schema, $table] = $this->splitTableName($candidate);
-            if ($this->tableExists($schema, $table)) {
-                $this->resolvedTable = $schema . '.' . $table;
-                return $this->resolvedTable;
-            }
-        }
-
-        $this->resolvedTable = self::TABLE_CANDIDATES[0];
-        return $this->resolvedTable;
-    }
-
-    /**
-     * @return array<string,array{name:string,type:string}>
-     */
-    private function tableColumns(): array
-    {
-        if ($this->columnInfo) {
-            return $this->columnInfo;
-        }
-
-        [$schema, $table] = $this->splitTableName($this->resolveTable());
-
-        $sql = 'SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = :schema AND table_name = :table';
-
-        try {
-            $rows = $this->db->fetchAll($sql, [
-                ':schema' => [$schema, PDO::PARAM_STR],
-                ':table'  => [$table, PDO::PARAM_STR],
-            ]);
-        } catch (\Throwable $e) {
-            $this->columnInfo = [];
-            return $this->columnInfo;
-        }
-
-        $info = [];
-        foreach ($rows as $row) {
-            if (!isset($row['column_name'])) {
-                continue;
-            }
-            $name = (string)$row['column_name'];
-            $type = isset($row['data_type']) ? (string)$row['data_type'] : 'text';
-            $info[strtolower($name)] = [
-                'name' => $name,
-                'type' => $type,
-            ];
-        }
-
-        $this->columnInfo = $info;
-        return $this->columnInfo;
-    }
-
-    private function column(string $logical): ?string
-    {
-        $map = [
-            'id'          => ['id', 'id_seguimiento', 'seguimiento_id'],
-            'coop'        => ['id_cooperativa', 'cooperativa_id', 'id_entidad'],
-            'fecha'       => ['fecha', 'fecha_actividad', 'fecha_seguimiento', 'dia', 'fecha_registro'],
-            'tipo'        => ['tipo', 'tipo_actividad', 'tipo_evento', 'categoria'],
-            'descripcion' => ['descripcion', 'detalle', 'comentario', 'observacion', 'nota'],
-            'ticket'      => ['ticket_id', 'id_ticket', 'ticket', 'ticket_numero'],
-            'usuario'     => ['creado_por', 'usuario_id', 'registrado_por', 'created_by'],
-            'created'     => ['created_at', 'creado_en', 'fecha_creacion', 'registrado_el'],
-            'contact_number' => ['numero_contacto', 'contact_number', 'num_contacto', 'contacto_numero'],
-            'contact_data'   => ['datos_contacto', 'contact_data', 'contacto_datos', 'contacto_json'],
-        ];
-
-        $candidates = $map[$logical] ?? [];
-        $columns = $this->tableColumns();
-
-        foreach ($candidates as $candidate) {
-            $lower = strtolower($candidate);
-            if (isset($columns[$lower])) {
-                return $columns[$lower]['name'];
-            }
-        }
-
-        return null;
-    }
-
-    private function requireColumn(string $logical): string
-    {
-        $column = $this->column($logical);
-        if ($column === null) {
-            throw new RuntimeException('No existe la columna requerida "' . $logical . '" en la tabla de seguimiento.');
-        }
-        return $column;
-    }
-
-    private function columnIsNumeric(string $logical): bool
-    {
-        $column = $this->column($logical);
-        if ($column === null) {
-            return false;
-        }
-
-        $columns = $this->tableColumns();
-        $info = $columns[strtolower($column)] ?? null;
-        if (!$info) {
-            return false;
-        }
-
-        $type = strtolower($info['type']);
-        return in_array($type, ['integer', 'bigint', 'smallint', 'numeric', 'decimal'], true);
-    }
-
-    private function tableExists(string $schema, string $table): bool
-    {
-        $sql = 'SELECT 1 FROM information_schema.tables WHERE table_schema = :schema AND table_name = :table LIMIT 1';
-
-        try {
-            $row = $this->db->fetch($sql, [
-                ':schema' => [$schema, PDO::PARAM_STR],
-                ':table'  => [$table, PDO::PARAM_STR],
-            ]);
-        } catch (\Throwable $e) {
-            return false;
-        }
-
-        return $row !== null;
-    }
-
-    private function findColumnName(string $schema, string $table, array $candidates): ?string
-    {
-        $sql = 'SELECT column_name FROM information_schema.columns WHERE table_schema = :schema AND table_name = :table';
-
-        try {
-            $rows = $this->db->fetchAll($sql, [
-                ':schema' => [$schema, PDO::PARAM_STR],
-                ':table'  => [$table, PDO::PARAM_STR],
-            ]);
-        } catch (\Throwable $e) {
-            return null;
-        }
-
-        $available = [];
-        foreach ($rows as $row) {
-            if (!isset($row['column_name'])) {
-                continue;
-            }
-            $available[strtolower((string)$row['column_name'])] = (string)$row['column_name'];
-        }
-
-        foreach ($candidates as $candidate) {
-            $key = strtolower($candidate);
-            if (isset($available[$key])) {
-                return $available[$key];
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @return array{0:string,1:string}
-     */
-    private function splitTableName(string $table): array
-    {
-        $parts = explode('.', $table, 2);
-        if (count($parts) === 2) {
-            return [$parts[0], $parts[1]];
-        }
-        return ['public', $parts[0]];
     }
 }

--- a/app/Views/Layouts/auth.php
+++ b/app/Views/Layouts/auth.php
@@ -7,9 +7,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="/css/app.css">
 </head>
-<body>
-  <main class="content-auth">
+<body class="auth-body">
+  <canvas id="auth-stars" aria-hidden="true"></canvas>
+  <main class="content-auth" role="main">
     <?php include $___viewFile; ?>
   </main>
+  <script src="/js/auth-stars.js" defer></script>
 </body>
 </html>

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -1,15 +1,21 @@
-<section class="card">
-  <h1>Ingresar</h1>
+<section class="auth-card" aria-labelledby="auth-heading">
+  <div class="auth-card__header">
+    <img class="auth-card__logo" src="/img/logo-galaxy.svg" alt="HelpDesk" width="160" height="64">
+    <h1 id="auth-heading">Bienvenido</h1>
+    <p class="auth-card__lead">Ingresa tus credenciales para acceder al panel de gestión.</p>
+  </div>
   <?php if (!empty($error)): ?>
-    <div class="alert alert-error"><?= htmlspecialchars($error) ?></div>
+    <div class="auth-card__alert" role="alert"><?= htmlspecialchars($error) ?></div>
   <?php endif; ?>
-  <form method="post" class="form">
-    <label>Usuario o Email
-      <input type="text" name="id" required autofocus>
-    </label>
-    <label>Contraseña
-      <input type="password" name="password" required>
-    </label>
-    <button class="btn btn-primary" type="submit">Entrar</button>
+  <form method="post" class="auth-form" autocomplete="on">
+    <div class="auth-field">
+      <label for="auth-id">Usuario o Email</label>
+      <input id="auth-id" type="text" name="id" required autofocus autocomplete="username">
+    </div>
+    <div class="auth-field">
+      <label for="auth-password">Contraseña</label>
+      <input id="auth-password" type="password" name="password" required autocomplete="current-password">
+    </div>
+    <button class="auth-submit" type="submit">Iniciar sesión</button>
   </form>
 </section>

--- a/app/Views/comercial/contactos/edit.php
+++ b/app/Views/comercial/contactos/edit.php
@@ -29,7 +29,8 @@ $fechaEvento  = $contacto['fecha_evento'] ?? date('Y-m-d');
 
   <section class="card" aria-labelledby="form-editar-contacto">
     <h2 id="form-editar-contacto" class="ent-title">Información del contacto</h2>
-    <form method="post" action="/comercial/contactos/<?= h((string)$contactId) ?>" class="form ent-form">
+    <form method="post" action="/comercial/contactos/<?= h((string)$contactId) ?>/editar" class="form ent-form">
+      <input type="hidden" name="id" value="<?= h((string)$contactId) ?>">
       <div class="form-row">
         <label for="contacto-entidad">Entidad</label>
         <select id="contacto-entidad" name="id_entidad" required>

--- a/app/Views/comercial/contactos/index.php
+++ b/app/Views/comercial/contactos/index.php
@@ -271,7 +271,8 @@ $today = date('Y-m-d');
         <span class="material-symbols-outlined" aria-hidden="true">close</span>
       </button>
     </div>
-    <form method="post" action="/comercial/contactos" class="form ent-form contact-modal__form" data-contact-edit-form>
+    <form method="post" action="" class="form ent-form contact-modal__form" data-contact-edit-form data-action-base="/comercial/contactos/">
+      <input type="hidden" name="id" value="" data-contact-id>
       <div class="form-row">
         <label for="modal-editar-contacto-entidad">Entidad</label>
         <select id="modal-editar-contacto-entidad" name="id_entidad" required>

--- a/app/Views/comercial/seguimiento/create.php
+++ b/app/Views/comercial/seguimiento/create.php
@@ -1,0 +1,122 @@
+<?php
+if (!function_exists('seguimiento_h')) {
+    function seguimiento_h($value): string
+    {
+        return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+$crumbs       = isset($crumbs) && is_array($crumbs) ? $crumbs : [];
+$cooperativas = isset($cooperativas) && is_array($cooperativas) ? $cooperativas : [];
+$tipos        = isset($tipos) && is_array($tipos) ? $tipos : [];
+
+include __DIR__ . '/../../partials/breadcrumbs.php';
+?>
+
+<section class="card ent-container">
+  <h1 class="ent-title">Nuevo seguimiento</h1>
+  <form class="seguimiento-form" method="post" action="/comercial/eventos" data-seguimiento-create>
+    <div class="seguimiento-form__row">
+      <div class="seguimiento-form__field">
+        <label for="nuevo-fecha-inicio">Fecha de inicio</label>
+        <input id="nuevo-fecha-inicio" type="date" name="fecha_inicio" required>
+      </div>
+      <div class="seguimiento-form__field">
+        <label for="nuevo-fecha-fin">Fecha de finalización</label>
+        <input id="nuevo-fecha-fin" type="date" name="fecha_fin">
+      </div>
+    </div>
+
+    <div class="seguimiento-form__field seguimiento-form__field--wide">
+      <label for="nuevo-entidad">Entidad</label>
+      <select id="nuevo-entidad" name="id_cooperativa" required>
+        <option value="">Seleccione</option>
+        <?php foreach ($cooperativas as $coop): ?>
+          <?php $value = isset($coop['id']) ? (string)$coop['id'] : ''; ?>
+          <option value="<?= seguimiento_h($value) ?>"><?= seguimiento_h($coop['nombre'] ?? '') ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+
+    <div class="seguimiento-form__field">
+      <label for="nuevo-tipo">Tipo de gestión</label>
+      <select id="nuevo-tipo" name="tipo" required>
+        <option value="">Seleccione</option>
+        <?php foreach ($tipos as $tipo): ?>
+          <?php $tipoNombre = (string)$tipo; ?>
+          <option value="<?= seguimiento_h($tipoNombre) ?>"><?= seguimiento_h($tipoNombre) ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+
+    <div class="seguimiento-form__field seguimiento-form__field--wide">
+      <label for="nuevo-descripcion">Descripción</label>
+      <textarea id="nuevo-descripcion" name="descripcion" rows="4" maxlength="600" required placeholder="Detalle de la gestión realizada"></textarea>
+    </div>
+
+    <section class="seguimiento-form__section" data-seguimiento-section="contacto" hidden>
+      <h2>Contacto relacionado</h2>
+      <div class="seguimiento-form__field">
+        <label for="nuevo-contacto">Seleccionar contacto</label>
+        <select id="nuevo-contacto" name="id_contacto">
+          <option value="">Seleccione</option>
+        </select>
+      </div>
+      <div class="seguimiento-contacto-resumen" data-contacto-resumen>
+        <div>
+          <span>Nombre</span>
+          <p data-contacto-dato="nombre"></p>
+        </div>
+        <div>
+          <span>Celular</span>
+          <p data-contacto-dato="telefono"></p>
+        </div>
+        <div>
+          <span>Correo</span>
+          <p data-contacto-dato="email"></p>
+        </div>
+      </div>
+    </section>
+
+    <section class="seguimiento-form__section" data-seguimiento-section="ticket" hidden>
+      <h2>Ticket relacionado</h2>
+      <div class="seguimiento-form__field">
+        <label for="nuevo-ticket-buscar">Buscar ticket</label>
+        <input id="nuevo-ticket-buscar" type="text" name="ticket_buscar" placeholder="Ej. INC-2025-00001" autocomplete="off">
+        <datalist id="nuevo-ticket-opciones"></datalist>
+        <input type="hidden" name="ticket_id" id="nuevo-ticket-id" value="">
+        <input type="hidden" name="ticket_datos" id="nuevo-ticket-datos" value="">
+      </div>
+      <div class="seguimiento-ticket-resumen" data-ticket-resumen>
+        <div>
+          <span>Código</span>
+          <p data-ticket-dato="codigo"></p>
+        </div>
+        <div>
+          <span>Departamento</span>
+          <p data-ticket-dato="departamento"></p>
+        </div>
+        <div>
+          <span>Tipo incidencia</span>
+          <p data-ticket-dato="tipo"></p>
+        </div>
+        <div>
+          <span>Prioridad</span>
+          <p data-ticket-dato="prioridad"></p>
+        </div>
+        <div>
+          <span>Estado</span>
+          <p data-ticket-dato="estado"></p>
+        </div>
+      </div>
+    </section>
+
+    <div class="seguimiento-form__actions">
+      <button type="submit" class="btn btn-primary">
+        <span class="material-symbols-outlined" aria-hidden="true">save</span>
+        Guardar
+      </button>
+      <a class="btn btn-cancel" href="/comercial/eventos">Cancelar</a>
+    </div>
+  </form>
+</section>

--- a/app/Views/comercial/seguimiento/index.php
+++ b/app/Views/comercial/seguimiento/index.php
@@ -28,15 +28,14 @@ $pages = $pagination->pages();
 $prev  = max(1, $page - 1);
 $next  = min($pages, $page + 1);
 
-$fechaFiltro = isset($filters['fecha']) ? (string)$filters['fecha'] : '';
-$desdeFiltro = isset($filters['desde']) ? (string)$filters['desde'] : '';
-$hastaFiltro = isset($filters['hasta']) ? (string)$filters['hasta'] : '';
-$coopFiltro  = isset($filters['coop']) ? (string)$filters['coop'] : '';
-$tipoFiltro  = isset($filters['tipo']) ? (string)$filters['tipo'] : '';
-$qFiltro     = isset($filters['q']) ? (string)$filters['q'] : '';
+$fechaFiltro  = isset($filters['fecha']) ? (string)$filters['fecha'] : '';
+$desdeFiltro  = isset($filters['desde']) ? (string)$filters['desde'] : '';
+$hastaFiltro  = isset($filters['hasta']) ? (string)$filters['hasta'] : '';
+$coopFiltro   = isset($filters['coop']) ? (string)$filters['coop'] : '';
+$tipoFiltro   = isset($filters['tipo']) ? (string)$filters['tipo'] : '';
+$qFiltro      = isset($filters['q']) ? (string)$filters['q'] : '';
 $ticketFiltro = isset($filters['ticket']) ? (string)$filters['ticket'] : '';
-
-$fechaForm = $fechaFiltro !== '' ? $fechaFiltro : date('Y-m-d');
+$advancedOpen = $hastaFiltro !== '' || $ticketFiltro !== '' || $fechaFiltro !== '';
 
 function buildSeguimientoPageUrl(int $pageNumber, array $filters, int $perPage): string
 {
@@ -75,47 +74,54 @@ function buildSeguimientoPageUrl(int $pageNumber, array $filters, int $perPage):
 
   <section class="seguimiento-card seguimiento-card--filters">
     <form class="seguimiento-filters" method="get" action="/comercial/eventos" role="search">
-      <div class="seguimiento-filters__field">
-        <label for="seguimiento-fecha">Fecha</label>
-        <input id="seguimiento-fecha" type="date" name="fecha" value="<?= seguimiento_h($fechaFiltro) ?>" data-default="<?= seguimiento_h($fechaForm) ?>">
+      <input type="hidden" name="fecha" value="<?= seguimiento_h($fechaFiltro) ?>">
+      <div class="seguimiento-filters__basic">
+        <div class="seguimiento-filters__field seguimiento-filters__field--wide">
+          <label for="seguimiento-q">Buscar descripción</label>
+          <input id="seguimiento-q" type="text" name="q" value="<?= seguimiento_h($qFiltro) ?>" placeholder="Buscar en las notas">
+        </div>
+        <div class="seguimiento-filters__field">
+          <label for="seguimiento-desde">Fecha de inicio</label>
+          <input id="seguimiento-desde" type="date" name="desde" value="<?= seguimiento_h($desdeFiltro) ?>">
+        </div>
+        <div class="seguimiento-filters__field">
+          <label for="seguimiento-coop">Entidad</label>
+          <select id="seguimiento-coop" name="coop">
+            <option value="">Todas</option>
+            <?php foreach ($cooperativas as $coop): ?>
+              <?php $value = isset($coop['id']) ? (string)$coop['id'] : ''; ?>
+              <option value="<?= seguimiento_h($value) ?>" <?= $value === $coopFiltro ? 'selected' : '' ?>><?= seguimiento_h($coop['nombre'] ?? '') ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="seguimiento-filters__field">
+          <label for="seguimiento-tipo">Tipo</label>
+          <select id="seguimiento-tipo" name="tipo">
+            <option value="">Todos</option>
+            <?php foreach ($tipos as $tipo): ?>
+              <?php $tipoNombre = (string)$tipo; ?>
+              <option value="<?= seguimiento_h($tipoNombre) ?>" <?= $tipoNombre === $tipoFiltro ? 'selected' : '' ?>><?= seguimiento_h($tipoNombre) ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
       </div>
-      <div class="seguimiento-filters__field">
-        <label for="seguimiento-desde">Desde</label>
-        <input id="seguimiento-desde" type="date" name="desde" value="<?= seguimiento_h($desdeFiltro) ?>">
-      </div>
-      <div class="seguimiento-filters__field">
-        <label for="seguimiento-hasta">Hasta</label>
-        <input id="seguimiento-hasta" type="date" name="hasta" value="<?= seguimiento_h($hastaFiltro) ?>">
-      </div>
-      <div class="seguimiento-filters__field">
-        <label for="seguimiento-coop">Cooperativa</label>
-        <select id="seguimiento-coop" name="coop">
-          <option value="">Todas</option>
-          <?php foreach ($cooperativas as $coop): ?>
-            <?php $value = isset($coop['id']) ? (string)$coop['id'] : ''; ?>
-            <option value="<?= seguimiento_h($value) ?>" <?= $value === $coopFiltro ? 'selected' : '' ?>><?= seguimiento_h($coop['nombre'] ?? '') ?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div class="seguimiento-filters__field">
-        <label for="seguimiento-tipo">Tipo</label>
-        <select id="seguimiento-tipo" name="tipo">
-          <option value="">Todos</option>
-          <?php foreach ($tipos as $tipo): ?>
-            <?php $tipoNombre = (string)$tipo; ?>
-            <option value="<?= seguimiento_h($tipoNombre) ?>" <?= $tipoNombre === $tipoFiltro ? 'selected' : '' ?>><?= seguimiento_h($tipoNombre) ?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div class="seguimiento-filters__field">
-        <label for="seguimiento-ticket">Ticket</label>
-        <input id="seguimiento-ticket" type="text" name="ticket" value="<?= seguimiento_h($ticketFiltro) ?>" placeholder="Ej. 1250">
-      </div>
-      <div class="seguimiento-filters__field seguimiento-filters__field--wide">
-        <label for="seguimiento-q">Descripción</label>
-        <input id="seguimiento-q" type="text" name="q" value="<?= seguimiento_h($qFiltro) ?>" placeholder="Buscar en las notas">
-      </div>
+
       <div class="seguimiento-filters__actions">
+        <button
+          type="button"
+          class="btn btn-ghost"
+          data-action="seguimiento-toggle-filtros"
+          aria-expanded="<?= $advancedOpen ? 'true' : 'false' ?>"
+          aria-controls="seguimiento-filtros-avanzados"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true">tune</span>
+          <span data-label-open<?= $advancedOpen ? ' hidden' : '' ?>>Más filtros</span>
+          <span data-label-close<?= $advancedOpen ? '' : ' hidden' ?>>Menos filtros</span>
+        </button>
+        <a class="btn btn-secondary" href="/comercial/eventos/crear">
+          <span class="material-symbols-outlined" aria-hidden="true">add</span>
+          Nuevo
+        </a>
         <button type="submit" class="btn btn-primary">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>
           Buscar
@@ -125,48 +131,32 @@ function buildSeguimientoPageUrl(int $pageNumber, array $filters, int $perPage):
           Limpiar
         </button>
       </div>
-    </form>
-  </section>
 
-  <section class="seguimiento-card seguimiento-card--form" aria-label="Registrar actividad del día">
-    <form class="seguimiento-form" method="post" action="/comercial/eventos">
-      <div class="seguimiento-form__field">
-        <label for="nuevo-fecha">Fecha de actividad</label>
-        <input id="nuevo-fecha" type="date" name="fecha" value="<?= seguimiento_h($fechaForm) ?>" required>
-      </div>
-      <div class="seguimiento-form__field">
-        <label for="nuevo-coop">Cooperativa</label>
-        <select id="nuevo-coop" name="id_cooperativa" required>
-          <option value="">Seleccione</option>
-          <?php foreach ($cooperativas as $coop): ?>
-            <?php $value = isset($coop['id']) ? (string)$coop['id'] : ''; ?>
-            <option value="<?= seguimiento_h($value) ?>"><?= seguimiento_h($coop['nombre'] ?? '') ?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div class="seguimiento-form__field">
-        <label for="nuevo-tipo">Tipo de gestión</label>
-        <select id="nuevo-tipo" name="tipo">
-          <option value="">Seguimiento</option>
-          <?php foreach ($tipos as $tipo): ?>
-            <?php $tipoNombre = (string)$tipo; ?>
-            <option value="<?= seguimiento_h($tipoNombre) ?>"><?= seguimiento_h($tipoNombre) ?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div class="seguimiento-form__field seguimiento-form__field--wide">
-        <label for="nuevo-descripcion">Descripción</label>
-        <textarea id="nuevo-descripcion" name="descripcion" rows="3" maxlength="600" required placeholder="Detalle del contacto o soporte realizado"></textarea>
-      </div>
-      <div class="seguimiento-form__field">
-        <label for="nuevo-ticket">Ticket relacionado</label>
-        <input id="nuevo-ticket" type="text" name="ticket" placeholder="Opcional">
-      </div>
-      <div class="seguimiento-form__actions">
-        <button type="submit" class="btn btn-primary">
-          <span class="material-symbols-outlined" aria-hidden="true">save</span>
-          Guardar
-        </button>
+      <div
+        class="seguimiento-filters__advanced"
+        id="seguimiento-filtros-avanzados"
+        data-seguimiento-filters-advanced
+        <?= $advancedOpen ? '' : 'hidden' ?>
+      >
+        <div class="seguimiento-filters__field">
+          <label for="seguimiento-hasta">Fecha de finalización</label>
+          <input id="seguimiento-hasta" type="date" name="hasta" value="<?= seguimiento_h($hastaFiltro) ?>">
+        </div>
+        <div class="seguimiento-filters__field seguimiento-filters__field--wide">
+          <label for="seguimiento-ticket">Ticket</label>
+          <input
+            id="seguimiento-ticket"
+            type="text"
+            name="ticket"
+            value="<?= seguimiento_h($ticketFiltro) ?>"
+            placeholder="Ej. INC-2025-00001"
+            autocomplete="off"
+            list="seguimiento-ticket-opciones"
+            data-ticket-filter
+          >
+          <datalist id="seguimiento-ticket-opciones"></datalist>
+          <p class="seguimiento-filters__hint">Escribe al menos 3 caracteres para ver sugerencias de tickets registrados.</p>
+        </div>
       </div>
     </form>
   </section>
@@ -183,86 +173,98 @@ function buildSeguimientoPageUrl(int $pageNumber, array $filters, int $perPage):
       <div class="seguimiento-cards">
         <?php foreach ($items as $item): ?>
           <?php
-            $fecha = isset($item['fecha']) ? (string)$item['fecha'] : '';
-            $fechaTexto = '';
-            if ($fecha !== '') {
-                $ts = strtotime($fecha);
-                if ($ts !== false) {
-                    $fechaTexto = date('d/m/Y', $ts);
-                }
+            $fechaInicio = isset($item['fecha_inicio']) ? (string)$item['fecha_inicio'] : '';
+            $fechaFin    = isset($item['fecha_fin']) ? (string)$item['fecha_fin'] : '';
+
+            $fechaInicioTexto = '';
+            if ($fechaInicio !== '' && ($tsInicio = strtotime($fechaInicio)) !== false) {
+                $fechaInicioTexto = date('d/m/Y', $tsInicio);
             }
-            $descripcion = isset($item['descripcion']) ? (string)$item['descripcion'] : '';
-            $ticket = isset($item['ticket']) ? trim((string)$item['ticket']) : '';
-            $usuario = isset($item['usuario']) ? (string)$item['usuario'] : '';
-            $creado = isset($item['creado_en']) ? (string)$item['creado_en'] : '';
-            $contactNumber = isset($item['contact_number']) ? (int)$item['contact_number'] : 0;
-            $contactDataRaw = $item['contact_data'] ?? null;
-            $contactData = '';
-            if (is_array($contactDataRaw)) {
-                $pairs = [];
-                foreach ($contactDataRaw as $key => $value) {
-                    if ($value === null || $value === '') {
-                        continue;
-                    }
-                    $label = is_string($key) ? trim((string)$key) : '';
-                    $textValue = is_scalar($value) ? trim((string)$value) : '';
-                    if ($textValue === '') {
-                        continue;
-                    }
-                    if ($label !== '') {
-                        $pairs[] = $label . ': ' . $textValue;
-                    } else {
-                        $pairs[] = $textValue;
-                    }
-                }
-                $contactData = implode('; ', $pairs);
-            } elseif (is_string($contactDataRaw)) {
-                $contactData = trim($contactDataRaw);
+
+            $fechaFinTexto = '';
+            if ($fechaFin !== '' && ($tsFin = strtotime($fechaFin)) !== false) {
+                $fechaFinTexto = date('d/m/Y', $tsFin);
+            }
+
+            $payload = [
+                'id'                  => isset($item['id']) ? (int)$item['id'] : 0,
+                'id_cooperativa'      => isset($item['id_cooperativa']) ? (int)$item['id_cooperativa'] : 0,
+                'entidad'             => isset($item['cooperativa']) ? (string)$item['cooperativa'] : '',
+                'cooperativa'         => isset($item['cooperativa']) ? (string)$item['cooperativa'] : '',
+                'fecha_inicio'        => $fechaInicio,
+                'fecha_inicio_texto'  => $fechaInicioTexto,
+                'fecha_fin'           => $fechaFin,
+                'fecha_fin_texto'     => $fechaFinTexto,
+                'tipo'                => isset($item['tipo']) ? (string)$item['tipo'] : '',
+                'descripcion'         => isset($item['descripcion']) ? (string)$item['descripcion'] : '',
+                'contacto_id'         => isset($item['id_contacto']) ? (int)$item['id_contacto'] : null,
+                'contacto_nombre'     => isset($item['contacto_nombre']) ? (string)$item['contacto_nombre'] : '',
+                'contacto_telefono'   => isset($item['contacto_telefono']) ? (string)$item['contacto_telefono'] : '',
+                'contacto_email'      => isset($item['contacto_email']) ? (string)$item['contacto_email'] : '',
+                'ticket_id'           => isset($item['ticket_id']) ? (int)$item['ticket_id'] : null,
+                'ticket_codigo'       => isset($item['ticket_codigo']) ? (string)$item['ticket_codigo'] : '',
+                'ticket_departamento' => isset($item['ticket_departamento']) ? (string)$item['ticket_departamento'] : '',
+                'ticket_tipo'         => isset($item['ticket_tipo']) ? (string)$item['ticket_tipo'] : '',
+                'ticket_prioridad'    => isset($item['ticket_prioridad']) ? (string)$item['ticket_prioridad'] : '',
+                'ticket_estado'       => isset($item['ticket_estado']) ? (string)$item['ticket_estado'] : '',
+                'datos_reunion'       => isset($item['datos_reunion']) ? $item['datos_reunion'] : null,
+                'datos_ticket'        => isset($item['datos_ticket']) ? $item['datos_ticket'] : null,
+                'usuario'             => isset($item['usuario']) ? (string)$item['usuario'] : '',
+                'creado_en'           => isset($item['creado_en']) ? (string)$item['creado_en'] : '',
+                'editado_en'          => isset($item['editado_en']) ? (string)$item['editado_en'] : '',
+            ];
+
+            $jsonPayload = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            if (!is_string($jsonPayload)) {
+                $jsonPayload = '{}';
             }
           ?>
-          <article class="seguimiento-card" tabindex="0">
+          <article
+            class="seguimiento-card"
+            role="button"
+            tabindex="0"
+            data-seguimiento-card
+            data-item='<?= seguimiento_h($jsonPayload) ?>'
+            aria-haspopup="dialog"
+            aria-label="Ver seguimiento de <?= seguimiento_h($item['cooperativa'] ?? '') ?>"
+            title="Ver seguimiento de <?= seguimiento_h($item['cooperativa'] ?? '') ?>"
+          >
             <span class="seguimiento-card__accent" aria-hidden="true"></span>
             <header class="seguimiento-card__header">
-              <div>
-                <p class="seguimiento-card__date"><?= seguimiento_h($fechaTexto ?: $fecha) ?></p>
-                <h2 class="seguimiento-card__title"><?= seguimiento_h($item['cooperativa'] ?? '') ?></h2>
-              </div>
+              <h2 class="seguimiento-card__title"><?= seguimiento_h($item['cooperativa'] ?? '') ?></h2>
               <?php if (!empty($item['tipo'])): ?>
                 <span class="seguimiento-card__badge"><?= seguimiento_h($item['tipo']) ?></span>
               <?php endif; ?>
             </header>
-            <p class="seguimiento-card__desc"><?= seguimiento_h($descripcion) ?></p>
-            <dl class="seguimiento-card__meta">
-              <?php if ($ticket !== ''): ?>
-                <div>
-                  <dt>Ticket</dt>
-                  <dd><?= seguimiento_h($ticket) ?></dd>
-                </div>
-              <?php endif; ?>
-              <?php if ($usuario !== ''): ?>
-                <div>
-                  <dt>Registrado por</dt>
-                  <dd><?= seguimiento_h($usuario) ?></dd>
-                </div>
-              <?php endif; ?>
-              <?php if ($creado !== ''): ?>
-                <div>
-                  <dt>Creado</dt>
-                  <dd><?= seguimiento_h($creado) ?></dd>
-                </div>
-              <?php endif; ?>
-              <?php if ($contactNumber > 0): ?>
-                <div>
-                  <dt>No. contacto</dt>
-                  <dd><?= seguimiento_h((string)$contactNumber) ?></dd>
-                </div>
-              <?php endif; ?>
-              <?php if ($contactData !== ''): ?>
-                <div>
-                  <dt>Detalle de contacto</dt>
-                  <dd><?= seguimiento_h($contactData) ?></dd>
-                </div>
-              <?php endif; ?>
+            <p class="seguimiento-card__desc"><?= seguimiento_h($item['descripcion'] ?? '') ?></p>
+            <dl class="seguimiento-card__meta seguimiento-card__meta--grid">
+              <div>
+                <dt>Fecha inicio</dt>
+                <dd>
+                  <?php $inicioVacio = $fechaInicioTexto === ''; ?>
+                  <span class="seguimiento-card__value<?= $inicioVacio ? ' seguimiento-card__value--empty' : '' ?>" data-field="inicio">
+                    <?= seguimiento_h($inicioVacio ? '' : $fechaInicioTexto) ?>
+                  </span>
+                </dd>
+              </div>
+              <div>
+                <dt>Fecha finalización</dt>
+                <dd>
+                  <?php $finVacio = $fechaFinTexto === ''; ?>
+                  <span class="seguimiento-card__value<?= $finVacio ? ' seguimiento-card__value--empty' : '' ?>" data-field="fin">
+                    <?= seguimiento_h($finVacio ? '' : $fechaFinTexto) ?>
+                  </span>
+                </dd>
+              </div>
+              <div>
+                <dt>Registrado por</dt>
+                <dd>
+                  <?php $usuarioTexto = isset($item['usuario']) ? (string)$item['usuario'] : ''; ?>
+                  <span class="seguimiento-card__value<?= $usuarioTexto === '' ? ' seguimiento-card__value--empty' : '' ?>" data-field="usuario">
+                    <?= seguimiento_h($usuarioTexto) ?>
+                  </span>
+                </dd>
+              </div>
             </dl>
           </article>
         <?php endforeach; ?>
@@ -286,4 +288,126 @@ function buildSeguimientoPageUrl(int $pageNumber, array $filters, int $perPage):
     </nav>
   <?php endif; ?>
 </section>
+
+<div class="seguimiento-modal" data-seguimiento-modal hidden>
+  <div class="seguimiento-modal__overlay" data-seguimiento-overlay></div>
+  <div class="seguimiento-modal__dialog" data-seguimiento-dialog role="dialog" aria-modal="true" aria-labelledby="seguimiento-modal-title">
+    <button type="button" class="seguimiento-modal__close" data-seguimiento-close aria-label="Cerrar detalle de seguimiento">
+      <span class="material-symbols-outlined" aria-hidden="true">close</span>
+    </button>
+    <header class="seguimiento-modal__header">
+      <h2 id="seguimiento-modal-title" data-seguimiento-modal-title>Detalle de seguimiento</h2>
+    </header>
+    <form class="seguimiento-modal__form seguimiento-form" data-seguimiento-form>
+      <input type="hidden" name="id" value="">
+      <div class="seguimiento-form__row">
+        <div class="seguimiento-form__field">
+          <label for="modal-fecha-inicio">Fecha de inicio</label>
+          <input id="modal-fecha-inicio" type="date" name="fecha_inicio" required>
+        </div>
+        <div class="seguimiento-form__field">
+          <label for="modal-fecha-fin">Fecha de finalización</label>
+          <input id="modal-fecha-fin" type="date" name="fecha_fin">
+        </div>
+      </div>
+
+      <div class="seguimiento-form__field seguimiento-form__field--wide">
+        <label for="modal-entidad">Entidad</label>
+        <select id="modal-entidad" name="id_cooperativa" required>
+          <option value="">Seleccione</option>
+          <?php foreach ($cooperativas as $coop): ?>
+            <?php $value = isset($coop['id']) ? (string)$coop['id'] : ''; ?>
+            <option value="<?= seguimiento_h($value) ?>"><?= seguimiento_h($coop['nombre'] ?? '') ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+
+      <div class="seguimiento-form__field">
+        <label for="modal-tipo">Tipo de gestión</label>
+        <select id="modal-tipo" name="tipo" required>
+          <option value="">Seleccione</option>
+          <?php foreach ($tipos as $tipo): ?>
+            <?php $tipoNombre = (string)$tipo; ?>
+            <option value="<?= seguimiento_h($tipoNombre) ?>"><?= seguimiento_h($tipoNombre) ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+
+      <div class="seguimiento-form__field seguimiento-form__field--wide">
+        <label for="modal-descripcion">Descripción</label>
+        <textarea id="modal-descripcion" name="descripcion" rows="4" maxlength="600" required></textarea>
+      </div>
+
+      <section class="seguimiento-form__section" data-seguimiento-section="contacto" hidden>
+        <h3>Contacto relacionado</h3>
+        <div class="seguimiento-form__field">
+          <label for="modal-contacto">Seleccionar contacto</label>
+          <select id="modal-contacto" name="id_contacto">
+            <option value="">Seleccione</option>
+          </select>
+        </div>
+        <div class="seguimiento-contacto-resumen" data-contacto-resumen>
+          <div>
+            <span>Nombre</span>
+            <p data-contacto-dato="nombre"></p>
+          </div>
+          <div>
+            <span>Celular</span>
+            <p data-contacto-dato="telefono"></p>
+          </div>
+          <div>
+            <span>Correo</span>
+            <p data-contacto-dato="email"></p>
+          </div>
+        </div>
+      </section>
+
+      <section class="seguimiento-form__section" data-seguimiento-section="ticket" hidden>
+        <h3>Ticket relacionado</h3>
+        <div class="seguimiento-form__field">
+          <label for="modal-ticket-buscar">Buscar ticket</label>
+          <input id="modal-ticket-buscar" type="text" name="ticket_buscar" placeholder="Ej. INC-2025-00001" autocomplete="off">
+          <datalist id="modal-ticket-opciones"></datalist>
+          <input type="hidden" name="ticket_id" id="modal-ticket-id" value="">
+          <input type="hidden" name="ticket_datos" id="modal-ticket-datos" value="">
+        </div>
+        <div class="seguimiento-ticket-resumen" data-ticket-resumen>
+          <div>
+            <span>Código</span>
+            <p data-ticket-dato="codigo"></p>
+          </div>
+          <div>
+            <span>Departamento</span>
+            <p data-ticket-dato="departamento"></p>
+          </div>
+          <div>
+            <span>Tipo incidencia</span>
+            <p data-ticket-dato="tipo"></p>
+          </div>
+          <div>
+            <span>Prioridad</span>
+            <p data-ticket-dato="prioridad"></p>
+          </div>
+          <div>
+            <span>Estado</span>
+            <p data-ticket-dato="estado"></p>
+          </div>
+        </div>
+      </section>
+
+      <div class="seguimiento-modal__meta" data-seguimiento-modal-meta></div>
+
+      <div class="seguimiento-modal__actions">
+        <button type="button" class="btn btn-primary" data-seguimiento-edit>
+          <span class="material-symbols-outlined" aria-hidden="true">edit</span>
+          Editar
+        </button>
+        <button type="button" class="btn btn-danger" data-seguimiento-delete>
+          <span class="material-symbols-outlined" aria-hidden="true">delete</span>
+          Eliminar
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
 <script src="/js/seguimiento.js" defer></script>

--- a/config/routes.php
+++ b/config/routes.php
@@ -83,12 +83,12 @@ $router->post(
     ['middleware'=>['auth','role:comercial']]
 );
 $router->get(
-    '/comercial/contactos/editar',
+    '/comercial/contactos/{id}/editar',
     [ContactosController::class, 'editForm'],
     ['middleware'=>['auth','role:comercial']]
 );
 $router->post(
-    '/comercial/contactos/{id}',
+    '/comercial/contactos/{id}/editar',
     [ContactosController::class, 'update'],
     ['middleware'=>['auth','role:comercial']]
 );
@@ -104,9 +104,44 @@ $router->get(
     [SeguimientoController::class, 'index'],
     ['middleware'=>['auth','role:comercial']]
 );
+$router->get(
+    '/comercial/eventos/contactos',
+    [SeguimientoController::class, 'contactos'],
+    ['middleware'=>['auth','role:comercial']]
+);
+$router->get(
+    '/comercial/eventos/sugerencias/tickets',
+    [SeguimientoController::class, 'ticketFilterSearch'],
+    ['middleware'=>['auth','role:comercial']]
+);
+$router->get(
+    '/comercial/eventos/tickets/buscar',
+    [SeguimientoController::class, 'ticketSearch'],
+    ['middleware'=>['auth','role:comercial']]
+);
+$router->get(
+    '/comercial/eventos/tickets/{id}',
+    [SeguimientoController::class, 'ticketInfo'],
+    ['middleware'=>['auth','role:comercial']]
+);
+$router->get(
+    '/comercial/eventos/crear',
+    [SeguimientoController::class, 'createForm'],
+    ['middleware'=>['auth','role:comercial']]
+);
 $router->post(
     '/comercial/eventos',
     [SeguimientoController::class, 'store'],
+    ['middleware'=>['auth','role:comercial']]
+);
+$router->post(
+    '/comercial/eventos/{id}',
+    [SeguimientoController::class, 'update'],
+    ['middleware'=>['auth','role:comercial']]
+);
+$router->post(
+    '/comercial/eventos/{id}/eliminar',
+    [SeguimientoController::class, 'delete'],
     ['middleware'=>['auth','role:comercial']]
 );
 $router->get(

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -89,7 +89,6 @@ h1 { color: var(--text-heading); margin: 0 0 12px; }
 .kpi { font-size:1.8rem; font-weight:700; color: var(--color-primary); }
 .kpi-label { color: var(--color-secondary); margin-top:6px; }
 /* Layout sin sidebar (login) */
-.content-auth { margin: 40px auto; max-width: 900px; padding: 24px; }
 .grid-2 { display:grid; grid-template-columns: repeat(2, minmax(220px,1fr)); gap:12px; }
 .col-span-2 { grid-column: span 2; }
 .chips { display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
@@ -98,3 +97,146 @@ h1 { color: var(--text-heading); margin: 0 0 12px; }
 .col-span-2{grid-column:span 2}
 .chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:6px}
 .chip{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border:1px solid #e3e3e3;border-radius:999px;background:#fff}
+
+/* ---- Auth Experience ---- */
+.auth-body {
+  min-height: 100vh;
+  margin: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(79,70,229,0.35), transparent 55%),
+              radial-gradient(circle at 80% 10%, rgba(236,72,153,0.30), transparent 50%),
+              #0f172a;
+  color: var(--text-inverse);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+#auth-stars {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  z-index: 0;
+}
+
+.content-auth {
+  position: relative;
+  z-index: 1;
+  width: min(420px, 92vw);
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+.auth-card {
+  backdrop-filter: blur(18px);
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 22px;
+  padding: 40px 36px 32px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.55);
+  color: #e2e8f0;
+}
+
+.auth-card__header {
+  text-align: center;
+  display: grid;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.auth-card__logo {
+  margin: 0 auto;
+  filter: drop-shadow(0 4px 16px rgba(59, 130, 246, 0.45));
+}
+
+.auth-card__lead {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.auth-card__alert {
+  border-radius: 12px;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  color: #fecaca;
+  text-align: center;
+}
+
+.auth-form {
+  display: grid;
+  gap: 18px;
+}
+
+.auth-field {
+  display: grid;
+  gap: 8px;
+}
+
+.auth-field label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.auth-field input {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  padding: 14px 16px;
+  color: #f8fafc;
+  font-size: 0.95rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-field input:focus {
+  outline: none;
+  border-color: rgba(129, 140, 248, 0.95);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35);
+}
+
+.auth-submit {
+  margin-top: 10px;
+  border: none;
+  border-radius: 16px;
+  padding: 14px 20px;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0f172a;
+  background: linear-gradient(135deg, #60a5fa, #c084fc 55%, #f472b6);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 35px rgba(96, 165, 250, 0.35);
+}
+
+.auth-submit:focus-visible {
+  outline: 2px solid #f8fafc;
+  outline-offset: 3px;
+}
+
+@media (max-width: 520px) {
+  .auth-card {
+    padding: 32px 24px 28px;
+  }
+
+  .auth-card__lead {
+    font-size: 0.9rem;
+  }
+
+  .auth-field input {
+    font-size: 0.9rem;
+    padding: 12px 14px;
+  }
+}

--- a/public/css/comercial_style/comercial-entidades.css
+++ b/public/css/comercial_style/comercial-entidades.css
@@ -1328,12 +1328,22 @@ body.is-modal-open{
   position: relative;
   overflow: hidden;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  gap: 0.85rem;
+  cursor: pointer;
 }
 
 .seguimiento-card:hover,
 .seguimiento-card:focus-within {
   transform: translateY(-6px);
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+}
+
+.seguimiento-card:focus-visible {
+  outline: 3px solid rgba(255, 102, 0, 0.45);
+  outline-offset: 4px;
 }
 
 .seguimiento-card__accent {
@@ -1356,14 +1366,7 @@ body.is-modal-open{
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.seguimiento-card__date {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: rgba(15, 23, 42, 0.55);
-  margin: 0 0 0.25rem 0;
+  margin-bottom: 0.15rem;
 }
 
 .seguimiento-card__title {
@@ -1387,10 +1390,15 @@ body.is-modal-open{
 }
 
 .seguimiento-card__desc {
-  margin: 0 0 1.1rem 0;
+  margin: 0;
   color: rgba(15, 23, 42, 0.78);
   line-height: 1.55;
   font-size: 0.96rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .seguimiento-card__meta {
@@ -1399,6 +1407,11 @@ body.is-modal-open{
   gap: 0.75rem 1.25rem;
   margin: 0;
   padding: 0;
+  margin-top: auto;
+}
+
+.seguimiento-card__meta--grid div {
+  min-height: 86px;
 }
 
 .seguimiento-card__meta div {
@@ -1422,6 +1435,26 @@ body.is-modal-open{
   font-size: 0.92rem;
 }
 
+.seguimiento-card__value {
+  display: block;
+  min-height: 1.25em;
+}
+
+.seguimiento-card__value--empty {
+  color: transparent;
+}
+
+.seguimiento-card__value--empty::after {
+  content: '';
+  display: block;
+  width: 100%;
+  min-width: 64px;
+  height: 2px;
+  margin-top: 0.15rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(15, 23, 42, 0.22), rgba(15, 23, 42, 0.08));
+}
+
 .seguimiento-card--filters,
 .seguimiento-card--form {
   border-left: 5px solid rgba(67, 97, 238, 0.2);
@@ -1429,9 +1462,15 @@ body.is-modal-open{
 }
 
 .seguimiento-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.seguimiento-filters__basic {
   display: grid;
   gap: 1rem 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .seguimiento-filters__field label,
@@ -1471,6 +1510,34 @@ body.is-modal-open{
   grid-column: 1 / -1;
 }
 
+.seguimiento-filters__advanced {
+  display: grid;
+  gap: 1rem 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  padding-top: 0.25rem;
+  border-top: 1px dashed rgba(67, 97, 238, 0.25);
+}
+
+.seguimiento-filters__hint {
+  margin: 0.35rem 0 0 0;
+  font-size: 0.75rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.btn-ghost {
+  background: rgba(67, 97, 238, 0.12);
+  color: #2f3e9e;
+  border-color: rgba(67, 97, 238, 0.18);
+}
+
+.btn-ghost:hover {
+  background: rgba(67, 97, 238, 0.22);
+}
+
+.btn-ghost:active {
+  background: rgba(67, 97, 238, 0.28);
+}
+
 .seguimiento-filters__actions,
 .seguimiento-form__actions {
   display: flex;
@@ -1495,7 +1562,15 @@ body.is-modal-open{
 .seguimiento-cards {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
+  align-items: stretch;
+}
+
+@media (max-width: 1200px) {
+  .seguimiento-cards {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
 }
 
 .seguimiento-empty {
@@ -1523,6 +1598,218 @@ body.is-modal-open{
   grid-column: 1 / -1;
 }
 
+body.seguimiento-modal-open {
+  overflow: hidden;
+}
+
+.seguimiento-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 1400;
+}
+
+.seguimiento-modal[hidden] {
+  display: none;
+}
+
+.seguimiento-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.seguimiento-modal__dialog {
+  position: relative;
+  background: #ffffff;
+  border-radius: 22px;
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.2);
+  width: min(700px, 100%);
+  max-height: min(90vh, 780px);
+  overflow: hidden auto;
+  padding: 2.2rem 2.4rem 2.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.seguimiento-modal__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding-right: 3.25rem;
+}
+
+.seguimiento-modal__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+  font-weight: 800;
+  color: #101828;
+}
+
+.seguimiento-modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 0;
+  background: rgba(15, 23, 42, 0.06);
+  color: #111827;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.seguimiento-modal__close:hover,
+.seguimiento-modal__close:focus {
+  background: rgba(67, 97, 238, 0.15);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.seguimiento-modal__close .material-symbols-outlined {
+  font-size: 1.5rem;
+}
+
+.seguimiento-modal__form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem 1.25rem;
+}
+
+.seguimiento-form__section {
+  grid-column: 1 / -1;
+  background: rgba(244, 247, 255, 0.8);
+  border-radius: 16px;
+  padding: 1.1rem 1.25rem 1.2rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.seguimiento-form__section h2,
+.seguimiento-form__section h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #1e2a55;
+}
+
+.seguimiento-contacto-resumen,
+.seguimiento-ticket-resumen {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.seguimiento-contacto-resumen div,
+.seguimiento-ticket-resumen div {
+  background: rgba(67, 97, 238, 0.08);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.seguimiento-contacto-resumen span,
+.seguimiento-ticket-resumen span {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.seguimiento-contacto-resumen p,
+.seguimiento-ticket-resumen p {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 0.95rem;
+}
+
+.seguimiento-modal__form .seguimiento-form__field--wide,
+.seguimiento-modal__form .seguimiento-modal__meta,
+.seguimiento-modal__form .seguimiento-modal__actions {
+  grid-column: 1 / -1;
+}
+
+.seguimiento-modal__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1.35rem;
+  padding: 0.85rem 1rem;
+  background: rgba(67, 97, 238, 0.08);
+  border-radius: 14px;
+  color: rgba(15, 23, 42, 0.7);
+  font-size: 0.9rem;
+}
+
+.seguimiento-modal__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.seguimiento-modal__meta-item .material-symbols-outlined {
+  font-size: 1.1rem;
+}
+
+.seguimiento-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.seguimiento-modal__actions .btn-outline {
+  border-color: rgba(15, 23, 42, 0.25);
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.seguimiento-modal__actions .btn-outline:hover,
+.seguimiento-modal__actions .btn-outline:focus {
+  border-color: rgba(67, 97, 238, 0.4);
+  color: rgba(67, 97, 238, 0.9);
+  outline: none;
+}
+
+.seguimiento-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  padding: 0.85rem 1.25rem;
+  border-radius: 14px;
+  font-weight: 600;
+  color: #fff;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.22);
+  background: rgba(17, 24, 39, 0.92);
+  opacity: 0;
+  transform: translateY(12px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 2500;
+}
+
+.seguimiento-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.seguimiento-toast--success {
+  background: rgba(22, 163, 74, 0.92);
+}
+
+.seguimiento-toast--error {
+  background: rgba(220, 38, 38, 0.92);
+}
+
 @media (max-width: 768px) {
   .ent-seguimiento {
     gap: 1.25rem;
@@ -1539,6 +1826,20 @@ body.is-modal-open{
   }
   .seguimiento-filters__actions,
   .seguimiento-form__actions {
+    justify-content: flex-start;
+  }
+  .seguimiento-modal {
+    padding: 1.5rem;
+  }
+  .seguimiento-modal__dialog {
+    padding: 1.75rem 1.5rem 1.85rem;
+    border-radius: 18px;
+    max-height: 92vh;
+  }
+  .seguimiento-modal__form {
+    grid-template-columns: 1fr;
+  }
+  .seguimiento-modal__actions {
     justify-content: flex-start;
   }
 }

--- a/public/img/logo-galaxy.svg
+++ b/public/img/logo-galaxy.svg
@@ -1,0 +1,30 @@
+<svg width="220" height="72" viewBox="0 0 220 72" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">HelpDesk Logo</title>
+  <desc id="desc">Logotipo actualizado de HelpDesk con gradientes en tonos morados y azules.</desc>
+  <defs>
+    <linearGradient id="ring" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="55%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#f472b6"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0.85"/>
+    </linearGradient>
+    <clipPath id="spark">
+      <rect x="10" y="10" width="52" height="52" rx="16"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#spark)" transform="translate(0,4)">
+    <rect x="10" y="10" width="52" height="52" rx="16" fill="rgba(15,23,42,0.35)"/>
+    <circle cx="36" cy="36" r="26" stroke="url(#ring)" stroke-width="6" fill="none"/>
+    <path d="M25 52V20h8v9h14v-9h8v32h-8v-14H33v14h-8z" fill="url(#glow)"/>
+    <path d="M21 18c5-5 12-8 19-8 7.2 0 13.9 3.2 18.6 8.5" stroke="rgba(148,163,184,0.4)" stroke-width="2.2" stroke-linecap="round" fill="none"/>
+  </g>
+  <g font-family="'Poppins', 'Segoe UI', 'Inter', sans-serif" font-weight="600" font-size="28" fill="#f8fafc" opacity="0.92" transform="translate(76,48)">
+    <text>Help</text>
+  </g>
+  <g font-family="'Poppins', 'Segoe UI', 'Inter', sans-serif" font-weight="500" font-size="24" fill="#cbd5f5" opacity="0.95" transform="translate(76,68)">
+    <text>Desk</text>
+  </g>
+</svg>

--- a/public/js/auth-stars.js
+++ b/public/js/auth-stars.js
@@ -1,0 +1,93 @@
+(function () {
+  const canvas = document.getElementById('auth-stars');
+  if (!canvas || !canvas.getContext) {
+    return;
+  }
+
+  const ctx = canvas.getContext('2d');
+  const STAR_COUNT = 520;
+  const stars = [];
+  let width = 0;
+  let height = 0;
+  let centerX = 0;
+  let centerY = 0;
+  let maxRadius = 0;
+  let pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+
+  class Star {
+    constructor(initial) {
+      this.reset(initial);
+    }
+
+    reset(initial) {
+      this.radius = initial ? Math.random() * maxRadius : 0;
+      this.angle = Math.random() * Math.PI * 2;
+      this.radialSpeed = 18 + Math.random() * 22;
+      this.angularSpeed = (Math.random() * 0.6 + 0.25) * (Math.random() < 0.5 ? -1 : 1);
+      this.size = Math.random() * 1.4 + 0.6;
+      this.alpha = Math.random() * 0.6 + 0.2;
+    }
+
+    update(delta) {
+      this.angle += this.angularSpeed * delta * 0.0015;
+      this.radius += this.radialSpeed * delta * 0.04;
+      if (this.radius > maxRadius) {
+        this.reset(false);
+      }
+    }
+
+    draw() {
+      const x = centerX + Math.cos(this.angle) * this.radius;
+      const y = centerY + Math.sin(this.angle) * this.radius;
+      ctx.beginPath();
+      ctx.fillStyle = `rgba(226, 232, 240, ${this.alpha})`;
+      ctx.arc(x, y, this.size, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  function resize() {
+    width = window.innerWidth;
+    height = window.innerHeight;
+    pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+
+    canvas.width = Math.floor(width * pixelRatio);
+    canvas.height = Math.floor(height * pixelRatio);
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+
+    ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    centerX = width / 2;
+    centerY = height / 2;
+    maxRadius = Math.sqrt(centerX * centerX + centerY * centerY);
+
+    if (!stars.length) {
+      for (let i = 0; i < STAR_COUNT; i++) {
+        stars.push(new Star(true));
+      }
+    }
+  }
+
+  let last = performance.now();
+
+  function frame(now) {
+    const delta = now - last;
+    last = now;
+
+    ctx.clearRect(0, 0, width, height);
+    ctx.globalCompositeOperation = 'lighter';
+
+    for (let i = 0; i < stars.length; i++) {
+      const star = stars[i];
+      star.update(delta);
+      star.draw();
+    }
+
+    ctx.globalCompositeOperation = 'source-over';
+    requestAnimationFrame(frame);
+  }
+
+  resize();
+  requestAnimationFrame(frame);
+  window.addEventListener('resize', resize, { passive: true });
+})();

--- a/public/js/contactos-typeahead.js
+++ b/public/js/contactos-typeahead.js
@@ -310,6 +310,7 @@
   if (!modal) { return; }
 
   const form = modal.querySelector('[data-contact-edit-form]');
+  const idField = modal.querySelector('[data-contact-id]');
   const entidad = modal.querySelector('#modal-editar-contacto-entidad');
   const nombre = modal.querySelector('#modal-editar-contacto-nombre');
   const titulo = modal.querySelector('#modal-editar-contacto-titulo');
@@ -318,11 +319,35 @@
   const correo = modal.querySelector('#modal-editar-contacto-correo');
   const nota = modal.querySelector('#modal-editar-contacto-nota');
   const fecha = modal.querySelector('#modal-editar-contacto-fecha');
+  const baseAction = form instanceof HTMLFormElement
+    ? (form.getAttribute('data-action-base') || '/comercial/contactos/')
+    : '/comercial/contactos/';
+
+  function normalizedBase() {
+    return baseAction.endsWith('/') ? baseAction : baseAction + '/';
+  }
 
   function setValue(field, value) {
     if (field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement || field instanceof HTMLSelectElement) {
       field.value = value || '';
     }
+  }
+
+  function configureAction(contactId) {
+    if (!(form instanceof HTMLFormElement)) { return; }
+    const url = normalizedBase() + encodeURIComponent(contactId) + '/editar';
+    form.setAttribute('action', url);
+  }
+
+  if (form instanceof HTMLFormElement) {
+    form.addEventListener('submit', (event) => {
+      const value = idField instanceof HTMLInputElement ? idField.value.trim() : '';
+      if (!value) {
+        event.preventDefault();
+        return;
+      }
+      configureAction(value);
+    });
   }
 
   document.querySelectorAll('[data-contact-edit]').forEach((button) => {
@@ -332,7 +357,11 @@
       const contactId = button.getAttribute('data-contact-id') || '';
       if (contactId === '') { return; }
 
-      form.setAttribute('action', '/comercial/contactos/' + encodeURIComponent(contactId));
+      if (idField instanceof HTMLInputElement) {
+        idField.value = contactId;
+      }
+
+      configureAction(contactId);
       setValue(entidad, button.getAttribute('data-contact-entidad') || '');
       setValue(nombre, button.getAttribute('data-contact-nombre') || '');
       setValue(titulo, button.getAttribute('data-contact-titulo') || '');

--- a/public/js/seguimiento.js
+++ b/public/js/seguimiento.js
@@ -1,17 +1,1030 @@
-
 (function () {
+  var contactCache = {};
+  var ticketCache = {};
+  var toastTimer = null;
+
+  function announce(message, variant) {
+    if (!message) {
+      return;
+    }
+    var region = document.querySelector('[data-seguimiento-toast]');
+    if (!region) {
+      region = document.createElement('div');
+      region.className = 'seguimiento-toast';
+      region.setAttribute('role', 'status');
+      region.setAttribute('aria-live', 'polite');
+      region.dataset.seguimientoToast = 'true';
+      document.body.appendChild(region);
+    }
+    region.classList.remove('seguimiento-toast--success', 'seguimiento-toast--error', 'is-visible');
+    region.textContent = message;
+    if (variant === 'error') {
+      region.classList.add('seguimiento-toast--error');
+    } else {
+      region.classList.add('seguimiento-toast--success');
+    }
+    region.classList.add('is-visible');
+    if (toastTimer) {
+      clearTimeout(toastTimer);
+    }
+    toastTimer = setTimeout(function () {
+      region.classList.remove('is-visible');
+    }, 3200);
+  }
+
+  function fetchJson(url, options) {
+    return fetch(url, options || {}).then(function (response) {
+      if (!response.ok) {
+        throw new Error('Error al comunicarse con el servidor');
+      }
+      return response.json();
+    });
+  }
+
   function handleReset(button) {
     var form = button.closest('form');
     if (!form) {
       return;
     }
-    var fechaField = form.querySelector('#seguimiento-fecha');
-    var defaultValue = fechaField ? fechaField.getAttribute('data-default') : '';
-    form.reset();
-    if (fechaField && defaultValue) {
-      fechaField.value = defaultValue;
+    var action = form.getAttribute('action') || window.location.pathname;
+    window.location.href = action;
+  }
+
+  function setupTicketFilterSearch(form) {
+    if (!form) {
+      return;
     }
-    form.submit();
+    var input = form.querySelector('[data-ticket-filter]');
+    if (!input) {
+      return;
+    }
+    var listId = input.getAttribute('list');
+    var datalist = listId ? document.getElementById(listId) : null;
+    var debounceTimer = null;
+
+    function clearOptions() {
+      if (!datalist) {
+        return;
+      }
+      datalist.innerHTML = '';
+    }
+
+    function populate(options) {
+      if (!datalist) {
+        return;
+      }
+      datalist.innerHTML = '';
+      options.forEach(function (item) {
+        if (!item) {
+          return;
+        }
+        var value = '';
+        if (item.codigo && item.codigo !== '') {
+          value = item.codigo;
+        } else if (item.ticket_id) {
+          value = 'Ticket #' + item.ticket_id;
+        } else if (item.descripcion) {
+          value = item.descripcion;
+        }
+        if (!value) {
+          return;
+        }
+        var label = value;
+        if (item.descripcion && item.descripcion !== value) {
+          label = value + ' — ' + item.descripcion;
+        }
+        var option = document.createElement('option');
+        option.value = value;
+        option.label = label;
+        option.textContent = label;
+        datalist.appendChild(option);
+      });
+    }
+
+    function performSearch(term) {
+      var normalized = term.trim();
+      if (normalized.length < 3) {
+        clearOptions();
+        return;
+      }
+      fetchJson('/comercial/eventos/sugerencias/tickets?q=' + encodeURIComponent(normalized))
+        .then(function (response) {
+          if (!response || !response.ok || !Array.isArray(response.items)) {
+            return;
+          }
+          populate(response.items);
+        })
+        .catch(function () {
+          clearOptions();
+        });
+    }
+
+    if (input.value && input.value.trim().length >= 3) {
+      performSearch(input.value);
+    }
+
+    input.addEventListener('input', function () {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+      var term = input.value || '';
+      debounceTimer = setTimeout(function () {
+        performSearch(term);
+      }, 220);
+    });
+  }
+
+  function setupFilters(form) {
+    if (!form) {
+      return;
+    }
+
+    var toggle = form.querySelector('[data-action="seguimiento-toggle-filtros"]');
+    var advanced = form.querySelector('[data-seguimiento-filters-advanced]');
+    var openLabel = toggle ? toggle.querySelector('[data-label-open]') : null;
+    var closeLabel = toggle ? toggle.querySelector('[data-label-close]') : null;
+
+    function setState(expanded) {
+      if (!toggle || !advanced) {
+        return;
+      }
+      if (expanded) {
+        advanced.hidden = false;
+        advanced.classList.add('is-open');
+        toggle.setAttribute('aria-expanded', 'true');
+        toggle.dataset.expanded = 'true';
+        if (openLabel) {
+          openLabel.setAttribute('hidden', '');
+        }
+        if (closeLabel) {
+          closeLabel.removeAttribute('hidden');
+        }
+      } else {
+        advanced.hidden = true;
+        advanced.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded', 'false');
+        toggle.dataset.expanded = 'false';
+        if (openLabel) {
+          openLabel.removeAttribute('hidden');
+        }
+        if (closeLabel) {
+          closeLabel.setAttribute('hidden', '');
+        }
+      }
+    }
+
+    if (toggle && advanced) {
+      var hasValue = false;
+      advanced.querySelectorAll('input, select').forEach(function (field) {
+        if (field.value && field.value !== '') {
+          hasValue = true;
+        }
+      });
+      var initiallyExpanded = toggle.getAttribute('aria-expanded') === 'true';
+      setState(hasValue || initiallyExpanded);
+
+      toggle.addEventListener('click', function (event) {
+        event.preventDefault();
+        var expanded = toggle.dataset.expanded === 'true';
+        setState(!expanded);
+      });
+    }
+
+    setupTicketFilterSearch(form);
+  }
+
+  function setSelectOptions(select, items, selected) {
+    if (!select) {
+      return;
+    }
+    var current = select.value;
+    while (select.options.length > 1) {
+      select.remove(1);
+    }
+    items.forEach(function (item) {
+      var option = document.createElement('option');
+      option.value = String(item.id);
+      option.textContent = item.nombre || ('Contacto #' + item.id);
+      select.appendChild(option);
+    });
+    if (selected) {
+      select.value = String(selected);
+    } else {
+      select.value = '';
+    }
+  }
+
+  function renderContactInfo(container, contact) {
+    if (!container) {
+      return;
+    }
+    var fields = container.querySelectorAll('[data-contacto-dato]');
+    fields.forEach(function (field) {
+      var key = field.getAttribute('data-contacto-dato');
+      var value = contact && key && contact[key] ? contact[key] : '—';
+      field.textContent = value && value !== '' ? value : '—';
+    });
+  }
+
+  function renderTicketInfo(container, data) {
+    if (!container) {
+      return;
+    }
+    var map = {
+      codigo: data && data.codigo ? data.codigo : '—',
+      departamento: data && data.departamento ? data.departamento : '—',
+      tipo: data && data.tipo ? data.tipo : '—',
+      prioridad: data && data.prioridad ? data.prioridad : '—',
+      estado: data && data.estado ? data.estado : '—',
+    };
+    var fields = container.querySelectorAll('[data-ticket-dato]');
+    fields.forEach(function (field) {
+      var key = field.getAttribute('data-ticket-dato');
+      field.textContent = key && Object.prototype.hasOwnProperty.call(map, key) ? map[key] : '—';
+    });
+  }
+
+  function toggleSections(typeValue, sections) {
+    var normalized = (typeValue || '').toLowerCase();
+    Object.keys(sections).forEach(function (key) {
+      var section = sections[key];
+      if (!section) {
+        return;
+      }
+      if (key === normalized) {
+        section.removeAttribute('hidden');
+      } else {
+        section.setAttribute('hidden', 'hidden');
+      }
+    });
+  }
+
+  function disableFormFields(form, disabled) {
+    if (!form) {
+      return;
+    }
+    var fields = form.querySelectorAll('input[type="date"], input[type="text"], textarea, select');
+    fields.forEach(function (field) {
+      field.disabled = disabled;
+    });
+  }
+
+  function loadContacts(entidadId) {
+    if (!entidadId || entidadId <= 0) {
+      return Promise.resolve([]);
+    }
+    if (contactCache[entidadId]) {
+      return Promise.resolve(contactCache[entidadId]);
+    }
+    return fetchJson('/comercial/eventos/contactos?entidad=' + entidadId).then(function (response) {
+      if (!response || !response.ok || !Array.isArray(response.items)) {
+        return [];
+      }
+      contactCache[entidadId] = response.items;
+      return response.items;
+    }).catch(function () {
+      return [];
+    });
+  }
+
+  function setupTicketSearch(config) {
+    var input = config.input;
+    if (!input) {
+      return;
+    }
+    var datalist = config.datalist;
+    var hiddenId = config.hiddenId;
+    var hiddenData = config.hiddenData;
+    var summary = config.summary;
+    var debounceTimer = null;
+    var lookup = {};
+
+    function writeHidden(ticket) {
+      if (hiddenId) {
+        hiddenId.value = ticket && ticket.id ? String(ticket.id) : '';
+      }
+      if (hiddenData) {
+        hiddenData.value = ticket ? JSON.stringify({
+          codigo: ticket.codigo || '',
+          departamento: ticket.departamento || '',
+          tipo: ticket.tipo || '',
+          prioridad: ticket.prioridad || '',
+          estado: ticket.estado || '',
+        }) : '';
+      }
+      renderTicketInfo(summary, ticket);
+    }
+
+    function performSearch(term) {
+      var normalized = term.trim();
+      if (normalized.length < 3) {
+        if (datalist) {
+          datalist.innerHTML = '';
+        }
+        lookup = {};
+        return;
+      }
+      fetchJson('/comercial/eventos/tickets/buscar?q=' + encodeURIComponent(normalized))
+        .then(function (response) {
+          if (!response || !response.ok || !Array.isArray(response.items)) {
+            return;
+          }
+          lookup = {};
+          if (datalist) {
+            datalist.innerHTML = '';
+          }
+          response.items.forEach(function (item) {
+            var key = item.codigo ? String(item.codigo).toUpperCase() : '';
+            if (key) {
+              lookup[key] = item;
+            }
+            if (datalist && item.codigo) {
+              var option = document.createElement('option');
+              option.value = item.codigo;
+              option.label = item.codigo + ' — ' + (item.titulo || '');
+              datalist.appendChild(option);
+            }
+          });
+        })
+        .catch(function () {
+          /* noop */
+        });
+    }
+
+    input.addEventListener('input', function () {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+      var term = input.value || '';
+      debounceTimer = setTimeout(function () {
+        performSearch(term);
+      }, 250);
+    });
+
+    input.addEventListener('change', function () {
+      var value = (input.value || '').trim();
+      if (!value) {
+        writeHidden(null);
+        return;
+      }
+      var key = value.toUpperCase();
+      var match = lookup[key];
+      if (!match && ticketCache[key]) {
+        match = ticketCache[key];
+      }
+      if (match) {
+        ticketCache[key] = match;
+        writeHidden(match);
+      } else {
+        // try fetching precise ticket by code
+        fetchJson('/comercial/eventos/tickets/buscar?q=' + encodeURIComponent(value)).then(function (response) {
+          if (response && Array.isArray(response.items) && response.items.length > 0) {
+            var item = response.items[0];
+            var newKey = item.codigo ? String(item.codigo).toUpperCase() : '';
+            if (newKey) {
+              lookup[newKey] = item;
+              ticketCache[newKey] = item;
+            }
+            writeHidden(item);
+          } else {
+            writeHidden(null);
+          }
+        }).catch(function () {
+          writeHidden(null);
+        });
+      }
+    });
+
+    if (hiddenId && hiddenId.value) {
+      var existingId = parseInt(hiddenId.value, 10);
+      if (!isNaN(existingId) && existingId > 0) {
+        fetchJson('/comercial/eventos/tickets/' + existingId)
+          .then(function (response) {
+            if (response && response.ok && response.item) {
+              var k = response.item.codigo ? String(response.item.codigo).toUpperCase() : '';
+              if (k) {
+                ticketCache[k] = response.item;
+              }
+              input.value = response.item.codigo || '';
+              writeHidden(response.item);
+            }
+          })
+          .catch(function () {
+            /* noop */
+          });
+      }
+    }
+  }
+
+  function setupCreateForm(form) {
+    if (!form) {
+      return;
+    }
+    var entidadSelect = form.querySelector('#nuevo-entidad');
+    var tipoSelect = form.querySelector('#nuevo-tipo');
+    var contactoSelect = form.querySelector('#nuevo-contacto');
+    var contactoResumen = form.querySelector('[data-contacto-resumen]');
+    var ticketInput = form.querySelector('#nuevo-ticket-buscar');
+    var ticketDatalist = form.querySelector('#nuevo-ticket-opciones');
+    var ticketIdField = form.querySelector('#nuevo-ticket-id');
+    var ticketDatosField = form.querySelector('#nuevo-ticket-datos');
+    var ticketResumen = form.querySelector('[data-ticket-resumen]');
+
+    var sections = {
+      contacto: form.querySelector('[data-seguimiento-section="contacto"]'),
+      ticket: form.querySelector('[data-seguimiento-section="ticket"]'),
+    };
+
+    renderContactInfo(contactoResumen, null);
+    renderTicketInfo(ticketResumen, null);
+
+    if (entidadSelect) {
+      entidadSelect.addEventListener('change', function () {
+        var entidadId = parseInt(entidadSelect.value, 10);
+        if (isNaN(entidadId) || entidadId <= 0) {
+          setSelectOptions(contactoSelect, [], null);
+          renderContactInfo(contactoResumen, null);
+          return;
+        }
+        loadContacts(entidadId).then(function (items) {
+          setSelectOptions(contactoSelect, items, null);
+          renderContactInfo(contactoResumen, null);
+        });
+      });
+    }
+
+    if (contactoSelect) {
+      contactoSelect.addEventListener('change', function () {
+        var entidadId = entidadSelect ? parseInt(entidadSelect.value, 10) : 0;
+        var contactId = parseInt(contactoSelect.value, 10);
+        if (isNaN(entidadId) || entidadId <= 0 || isNaN(contactId) || contactId <= 0) {
+          renderContactInfo(contactoResumen, null);
+          return;
+        }
+        loadContacts(entidadId).then(function (items) {
+          var found = items.find(function (item) {
+            return item.id === contactId;
+          });
+          renderContactInfo(contactoResumen, found || null);
+        });
+      });
+    }
+
+    if (tipoSelect) {
+      tipoSelect.addEventListener('change', function () {
+        toggleSections(tipoSelect.value, sections);
+      });
+      toggleSections(tipoSelect.value, sections);
+    }
+
+    setupTicketSearch({
+      input: ticketInput,
+      datalist: ticketDatalist,
+      hiddenId: ticketIdField,
+      hiddenData: ticketDatosField,
+      summary: ticketResumen,
+    });
+  }
+
+  function setupModal() {
+    var modal = document.querySelector('[data-seguimiento-modal]');
+    if (!modal) {
+      return;
+    }
+
+    var overlay = modal.querySelector('[data-seguimiento-overlay]');
+    var dialog = modal.querySelector('[data-seguimiento-dialog]');
+    var closeBtn = modal.querySelector('[data-seguimiento-close]');
+    var form = modal.querySelector('[data-seguimiento-form]');
+    var editBtn = modal.querySelector('[data-seguimiento-edit]');
+    var deleteBtn = modal.querySelector('[data-seguimiento-delete]');
+    var titleEl = modal.querySelector('[data-seguimiento-modal-title]');
+    var metaContainer = modal.querySelector('[data-seguimiento-modal-meta]');
+
+    if (!form) {
+      return;
+    }
+
+    var idField = form.querySelector('input[name="id"]');
+    var fechaInicioField = form.querySelector('#modal-fecha-inicio');
+    var fechaFinField = form.querySelector('#modal-fecha-fin');
+    var entidadField = form.querySelector('#modal-entidad');
+    var tipoField = form.querySelector('#modal-tipo');
+    var descripcionField = form.querySelector('#modal-descripcion');
+    var contactoSelect = form.querySelector('#modal-contacto');
+    var contactoResumen = form.querySelector('[data-contacto-resumen]');
+    var ticketInput = form.querySelector('#modal-ticket-buscar');
+    var ticketDatalist = form.querySelector('#modal-ticket-opciones');
+    var ticketIdField = form.querySelector('#modal-ticket-id');
+    var ticketDatosField = form.querySelector('#modal-ticket-datos');
+    var ticketResumen = form.querySelector('[data-ticket-resumen]');
+
+    var sections = {
+      contacto: form.querySelector('[data-seguimiento-section="contacto"]'),
+      ticket: form.querySelector('[data-seguimiento-section="ticket"]'),
+    };
+
+    var currentData = null;
+    var currentCard = null;
+    var editing = false;
+    var lastFocused = null;
+
+    setupTicketSearch({
+      input: ticketInput,
+      datalist: ticketDatalist,
+      hiddenId: ticketIdField,
+      hiddenData: ticketDatosField,
+      summary: ticketResumen,
+    });
+
+    if (entidadField) {
+      entidadField.addEventListener('change', function () {
+        if (!editing) {
+          return;
+        }
+        var entidadId = parseInt(entidadField.value, 10);
+        if (isNaN(entidadId) || entidadId <= 0) {
+          setSelectOptions(contactoSelect, [], null);
+          renderContactInfo(contactoResumen, null);
+          return;
+        }
+        loadContacts(entidadId).then(function (items) {
+          setSelectOptions(contactoSelect, items, null);
+          renderContactInfo(contactoResumen, null);
+        });
+      });
+    }
+
+    if (tipoField) {
+      tipoField.addEventListener('change', function () {
+        toggleSections(tipoField.value, sections);
+        var normalized = (tipoField.value || '').toLowerCase();
+        if (normalized !== 'contacto') {
+          if (contactoSelect) {
+            contactoSelect.value = '';
+          }
+          renderContactInfo(contactoResumen, null);
+        }
+        if (normalized !== 'ticket') {
+          if (ticketInput) {
+            ticketInput.value = '';
+          }
+          if (ticketIdField) {
+            ticketIdField.value = '';
+          }
+          if (ticketDatosField) {
+            ticketDatosField.value = '';
+          }
+          renderTicketInfo(ticketResumen, null);
+        }
+      });
+    }
+
+    if (contactoSelect) {
+      contactoSelect.addEventListener('change', function () {
+        if (!currentData) {
+          return;
+        }
+        var entidadId = parseInt(entidadField ? entidadField.value : '0', 10);
+        var contactId = parseInt(contactoSelect.value, 10);
+        if (isNaN(entidadId) || entidadId <= 0 || isNaN(contactId) || contactId <= 0) {
+          renderContactInfo(contactoResumen, null);
+          return;
+        }
+        loadContacts(entidadId).then(function (items) {
+          var found = items.find(function (item) { return item.id === contactId; });
+          renderContactInfo(contactoResumen, found || null);
+        });
+      });
+    }
+
+    function renderMeta(data) {
+      if (!metaContainer) {
+        return;
+      }
+      metaContainer.innerHTML = '';
+      var chips = [];
+      if (data.usuario) {
+        chips.push({ icon: 'person', text: 'Registrado por ' + data.usuario });
+      }
+      if (data.creado_en) {
+        chips.push({ icon: 'schedule', text: data.creado_en });
+      }
+      if (data.editado_en) {
+        chips.push({ icon: 'update', text: 'Actualizado ' + data.editado_en });
+      }
+      if (data.id) {
+        chips.push({ icon: 'tag', text: 'ID #' + data.id });
+      }
+      if (chips.length === 0) {
+        metaContainer.setAttribute('hidden', 'hidden');
+        return;
+      }
+      metaContainer.removeAttribute('hidden');
+      chips.forEach(function (chip) {
+        var span = document.createElement('span');
+        span.className = 'seguimiento-modal__meta-item';
+        var icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined';
+        icon.setAttribute('aria-hidden', 'true');
+        icon.textContent = chip.icon;
+        var text = document.createElement('span');
+        text.textContent = chip.text;
+        span.appendChild(icon);
+        span.appendChild(text);
+        metaContainer.appendChild(span);
+      });
+    }
+
+    function applyData(data) {
+      if (!data) {
+        return;
+      }
+      var entityName = data.entidad || data.cooperativa || '';
+      if (!data.entidad && entityName) {
+        data.entidad = entityName;
+      }
+      if (!data.cooperativa && entityName) {
+        data.cooperativa = entityName;
+      }
+      disableFormFields(form, true);
+      editing = false;
+      if (editBtn) {
+        editBtn.innerHTML = '<span class="material-symbols-outlined" aria-hidden="true">edit</span>Editar';
+      }
+      if (idField) {
+        idField.value = data.id ? String(data.id) : '';
+      }
+      if (fechaInicioField) {
+        fechaInicioField.value = data.fecha_inicio || '';
+      }
+      if (fechaFinField) {
+        fechaFinField.value = data.fecha_fin || '';
+      }
+      if (entidadField) {
+        entidadField.value = data.id_cooperativa ? String(data.id_cooperativa) : '';
+      }
+      if (tipoField) {
+        setSelectValue(tipoField, data.tipo || '');
+      }
+      if (descripcionField) {
+        descripcionField.value = data.descripcion || '';
+      }
+      if (titleEl) {
+        titleEl.textContent = entityName || 'Detalle de seguimiento';
+      }
+      toggleSections(data.tipo || '', sections);
+
+      if (entidadField && contactoSelect) {
+        var entidadId = parseInt(entidadField.value, 10);
+        if (!isNaN(entidadId) && entidadId > 0) {
+          loadContacts(entidadId).then(function (items) {
+            setSelectOptions(contactoSelect, items, data.id_contacto || null);
+            var found = items.find(function (item) { return data.id_contacto && item.id === data.id_contacto; });
+            renderContactInfo(contactoResumen, found || null);
+          });
+        } else {
+          setSelectOptions(contactoSelect, [], null);
+          renderContactInfo(contactoResumen, null);
+        }
+      }
+
+      if (ticketInput) {
+        ticketInput.value = data.ticket_codigo || '';
+      }
+      if (ticketIdField) {
+        ticketIdField.value = data.ticket_id ? String(data.ticket_id) : '';
+      }
+      if (ticketDatosField) {
+        ticketDatosField.value = data.datos_ticket ? JSON.stringify(data.datos_ticket) : '';
+      }
+      renderTicketInfo(ticketResumen, data.datos_ticket || {
+        codigo: data.ticket_codigo || '',
+        departamento: data.ticket_departamento || '',
+        tipo: data.ticket_tipo || '',
+        prioridad: data.ticket_prioridad || '',
+        estado: data.ticket_estado || '',
+      });
+
+      renderMeta(data);
+    }
+
+    function setSelectValue(select, value) {
+      if (!select) {
+        return;
+      }
+      var normalized = value ? String(value) : '';
+      var exists = false;
+      for (var i = 0; i < select.options.length; i++) {
+        if (select.options[i].value === normalized) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists && normalized !== '') {
+        var option = document.createElement('option');
+        option.value = normalized;
+        option.textContent = normalized;
+        option.setAttribute('data-generated', 'true');
+        select.appendChild(option);
+      }
+      select.value = normalized;
+    }
+
+    function toggleEdit() {
+      if (!currentData) {
+        return;
+      }
+      editing = !editing;
+      if (editing) {
+        disableFormFields(form, false);
+        if (editBtn) {
+          editBtn.innerHTML = '<span class="material-symbols-outlined" aria-hidden="true">save</span>Guardar';
+        }
+        if (fechaInicioField && typeof fechaInicioField.focus === 'function') {
+          fechaInicioField.focus();
+        }
+      } else {
+        disableFormFields(form, true);
+        if (editBtn) {
+          editBtn.innerHTML = '<span class="material-symbols-outlined" aria-hidden="true">edit</span>Editar';
+        }
+      }
+      toggleSections(tipoField ? tipoField.value : '', sections);
+    }
+
+    function closeModal() {
+      if (!modal.classList.contains('is-open')) {
+        return;
+      }
+      modal.classList.remove('is-open');
+      modal.setAttribute('hidden', 'hidden');
+      document.body.classList.remove('seguimiento-modal-open');
+      disableFormFields(form, true);
+      editing = false;
+      if (editBtn) {
+        editBtn.innerHTML = '<span class="material-symbols-outlined" aria-hidden="true">edit</span>Editar';
+      }
+      if (lastFocused && typeof lastFocused.focus === 'function') {
+        lastFocused.focus();
+      }
+      currentCard = null;
+      currentData = null;
+    }
+
+    function openModal(card, data) {
+      currentCard = card;
+      currentData = data;
+      if (currentData && !currentData.entidad && currentData.cooperativa) {
+        currentData.entidad = currentData.cooperativa;
+      }
+      lastFocused = document.activeElement;
+      modal.removeAttribute('hidden');
+      modal.classList.add('is-open');
+      document.body.classList.add('seguimiento-modal-open');
+      applyData(data);
+      var focusTarget = closeBtn || dialog;
+      if (focusTarget && typeof focusTarget.focus === 'function') {
+        setTimeout(function () {
+          focusTarget.focus();
+        }, 80);
+      }
+    }
+
+    function formatDate(value) {
+      if (!value) {
+        return '';
+      }
+      var parts = String(value).split('-');
+      if (parts.length === 3) {
+        return parts[2] + '/' + parts[1] + '/' + parts[0];
+      }
+      return value;
+    }
+
+    function refreshCard(data) {
+      if (!currentCard) {
+        return;
+      }
+      var payload = {
+        id: data.id,
+        id_cooperativa: data.id_cooperativa,
+        entidad: data.entidad || data.cooperativa || '',
+        cooperativa: data.cooperativa || data.entidad || '',
+        fecha_inicio: data.fecha_inicio,
+        fecha_inicio_texto: data.fecha_inicio ? formatDate(data.fecha_inicio) : '',
+        fecha_fin: data.fecha_fin,
+        fecha_fin_texto: data.fecha_fin ? formatDate(data.fecha_fin) : '',
+        tipo: data.tipo,
+        descripcion: data.descripcion,
+        contacto_id: data.id_contacto,
+        contacto_nombre: data.contacto_nombre,
+        contacto_telefono: data.contacto_telefono,
+        contacto_email: data.contacto_email,
+        ticket_id: data.ticket_id,
+        ticket_codigo: data.ticket_codigo,
+        ticket_departamento: data.ticket_departamento,
+        ticket_tipo: data.ticket_tipo,
+        ticket_prioridad: data.ticket_prioridad,
+        ticket_estado: data.ticket_estado,
+        datos_reunion: data.datos_reunion,
+        datos_ticket: data.datos_ticket,
+        usuario: data.usuario,
+        creado_en: data.creado_en,
+        editado_en: data.editado_en,
+      };
+      try {
+        currentCard.setAttribute('data-item', JSON.stringify(payload));
+      } catch (error) {
+        currentCard.setAttribute('data-item', '{}');
+      }
+      var title = currentCard.querySelector('.seguimiento-card__title');
+      if (title) {
+        title.textContent = payload.cooperativa || '';
+      }
+      var desc = currentCard.querySelector('.seguimiento-card__desc');
+      if (desc) {
+        desc.textContent = data.descripcion || '';
+      }
+      var badge = currentCard.querySelector('.seguimiento-card__badge');
+      if (badge) {
+        badge.textContent = data.tipo || '';
+      }
+      var inicioEl = currentCard.querySelector('[data-field="inicio"]');
+      if (inicioEl) {
+        var inicioTexto = formatDate(data.fecha_inicio);
+        inicioEl.textContent = inicioTexto;
+        inicioEl.classList.toggle('seguimiento-card__value--empty', !inicioTexto);
+      }
+      var finEl = currentCard.querySelector('[data-field="fin"]');
+      if (finEl) {
+        var finTexto = formatDate(data.fecha_fin);
+        finEl.textContent = finTexto;
+        finEl.classList.toggle('seguimiento-card__value--empty', !finTexto);
+      }
+      var usuarioEl = currentCard.querySelector('[data-field="usuario"]');
+      if (usuarioEl) {
+        var usuarioTexto = data.usuario || '';
+        usuarioEl.textContent = usuarioTexto;
+        usuarioEl.classList.toggle('seguimiento-card__value--empty', !usuarioTexto);
+      }
+    }
+
+    function submitUpdate() {
+      if (!currentData || !idField || !idField.value) {
+        return;
+      }
+      var formData = new FormData(form);
+      fetch('/comercial/eventos/' + encodeURIComponent(idField.value), {
+        method: 'POST',
+        body: formData,
+      })
+        .then(function (response) {
+          return response.json().catch(function () { return {}; });
+        })
+        .then(function (payload) {
+          if (!payload || !payload.ok || !payload.item) {
+            var message = 'No se pudo actualizar el seguimiento.';
+            if (payload && Array.isArray(payload.errors) && payload.errors.length) {
+              message = payload.errors.join(' ');
+            }
+            announce(message, 'error');
+            return;
+          }
+          currentData = payload.item;
+          if (currentData && !currentData.entidad && currentData.cooperativa) {
+            currentData.entidad = currentData.cooperativa;
+          }
+          applyData(currentData);
+          refreshCard(currentData);
+          announce('Información actualizada correctamente', 'success');
+        })
+        .catch(function () {
+          announce('Ocurrió un error al actualizar el seguimiento.', 'error');
+        });
+    }
+
+    if (editBtn) {
+      editBtn.addEventListener('click', function () {
+        if (!currentData) {
+          return;
+        }
+        if (!editing) {
+          toggleEdit();
+        } else {
+          submitUpdate();
+        }
+      });
+    }
+
+    if (deleteBtn) {
+      deleteBtn.addEventListener('click', function () {
+        if (!currentData || !currentData.id) {
+          return;
+        }
+        if (!window.confirm('¿Estás seguro de eliminar el seguimiento?')) {
+          return;
+        }
+        var cardToRemove = currentCard;
+        fetch('/comercial/eventos/' + encodeURIComponent(currentData.id) + '/eliminar', {
+          method: 'POST',
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+        })
+          .then(function (response) {
+            return response.json().catch(function () {
+              return {};
+            });
+          })
+          .then(function (payload) {
+            if (!payload || !payload.ok) {
+              var message = 'No se pudo eliminar el seguimiento.';
+              if (payload && Array.isArray(payload.errors) && payload.errors.length) {
+                message = payload.errors.join(' ');
+              }
+              announce(message, 'error');
+              return;
+            }
+            closeModal();
+            if (cardToRemove && cardToRemove.parentElement) {
+              cardToRemove.parentElement.removeChild(cardToRemove);
+            }
+            announce('Seguimiento eliminado correctamente.', 'success');
+          })
+          .catch(function () {
+            announce('Ocurrió un error al eliminar el seguimiento.', 'error');
+          });
+      });
+    }
+
+    if (overlay) {
+      overlay.addEventListener('click', closeModal);
+    }
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function (event) {
+        event.preventDefault();
+        closeModal();
+      });
+    }
+
+    modal.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeModal();
+      }
+    });
+
+    if (dialog) {
+      dialog.addEventListener('click', function (event) {
+        event.stopPropagation();
+      });
+    }
+
+    disableFormFields(form, true);
+
+    if (form) {
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+      });
+    }
+
+    document.querySelectorAll('[data-seguimiento-card]').forEach(function (card) {
+      function parseData() {
+        var raw = card.getAttribute('data-item');
+        if (!raw) {
+          return null;
+        }
+        try {
+          var parsed = JSON.parse(raw);
+          if (parsed && !parsed.cooperativa && parsed.entidad) {
+            parsed.cooperativa = parsed.entidad;
+          }
+          if (parsed && !parsed.entidad && parsed.cooperativa) {
+            parsed.entidad = parsed.cooperativa;
+          }
+          return parsed;
+        } catch (error) {
+          return null;
+        }
+      }
+      card.addEventListener('click', function () {
+        var data = parseData();
+        if (data) {
+          openModal(card, data);
+        }
+      });
+      card.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          var data = parseData();
+          if (data) {
+            openModal(card, data);
+          }
+        }
+      });
+    });
   }
 
   document.addEventListener('DOMContentLoaded', function () {
@@ -22,5 +1035,10 @@
         handleReset(resetBtn);
       });
     }
+
+    var filtersForm = document.querySelector('.seguimiento-filters');
+    setupFilters(filtersForm);
+    setupCreateForm(document.querySelector('[data-seguimiento-create]'));
+    setupModal();
   });
 })();


### PR DESCRIPTION
## Summary
- update the auth layout and login view to showcase a refreshed logo and hero messaging
- style the login card with glassmorphism, responsive typography, and integrate the new gradient logo asset
- render a canvas-based starfield animation for the background via a dedicated JavaScript helper
- add seguimiento filter suggestions, advanced toggle fixes, and API endpoints for ticket search and deletion
- wire the seguimiento modal to support confirmable deletions and clean filter resets on the listing

## Testing
- php -l app/Views/Layouts/auth.php
- php -l app/Views/auth/login.php
- php -l app/Controllers/Comercial/SeguimientoController.php
- php -l app/Repositories/Comercial/SeguimientoRepository.php
- php -l app/Views/comercial/seguimiento/index.php
- php -l config/routes.php

------
https://chatgpt.com/codex/tasks/task_e_68ed61fcc9e883269280c904ec55a2db