### PR TITLE
Organize seguimiento date inputs and conditional sections

### DIFF
--- a/public/css/comercial_style/comercial-entidades.css
+++ b/public/css/comercial_style/comercial-entidades.css
@@ -1610,6 +1610,13 @@ body.is-modal-open{
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
+.seguimiento-form__row {
+  display: grid;
+  gap: 1rem 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-column: 1 / -1;
+}
+
 .seguimiento-form__field--wide {
   grid-column: 1 / -1;
 }


### PR DESCRIPTION
## Summary
- align the seguimiento date fields side by side within the form layout
- only reveal the related contact or ticket sections when the selected tipo de gestión requires them
- normalize tipo values and reset hidden form data to avoid stale selections when switching types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2d2162c248326a95d08e98b32e36d