### PR TITLE
Use incidencias for seguimiento ticket lookup

### DIFF
--- a/public/css/comercial_style/comercial-entidades.css
+++ b/public/css/comercial_style/comercial-entidades.css
@@ -1610,6 +1610,13 @@ body.is-modal-open{
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
+.seguimiento-form__row {
+  display: grid;
+  gap: 1rem 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-column: 1 / -1;
+}
+
 .seguimiento-form__field--wide {
   grid-column: 1 / -1;
 }


### PR DESCRIPTION
## Summary
- update the seguimiento repository to pull related ticket data from incidencias_comercial instead of the legacy tickets view
- generate the INC-YYYY-##### codes directly from incidencias metadata and keep department/type/priority details in sync
- improve ticket lookups by falling back to descriptions when an incidencia lacks a title

## Testing
- php -l app/Repositories/Comercial/SeguimientoRepository.php

------
https://chatgpt.com/codex/tasks/task_e_68f2d2162c248326a95d08e98b32e36d